### PR TITLE
Rc 0.1.1

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-02-10.
+Once it is accepted, delete this file and tag the release (commit 010fe893a3).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,2 @@
-This package was submitted to CRAN on 2020-02-10.
-Once it is accepted, delete this file and tag the release (commit 010fe893a3).
+This package was submitted to CRAN on 2020-02-22.
+Once it is accepted, delete this file and tag the release (commit 8148e19f8b).

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2020-02-22.
-Once it is accepted, delete this file and tag the release (commit 8148e19f8b).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: slider
 Title: Sliding Window Functions
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R: 
     c(person(given = "Davis",
              family = "Vaughan",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# slider (development version)
+# slider 0.1.1
 
 * Fixed a "multiple definition" C issue when compiling with gcc10.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,9 +5,12 @@
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* This is a new release.
+## 0.1.1 Submission
+
+Fixes a multiple declaration C issue uncovered by CRAN's check under gcc10. We
+link against the vctrs C API, which also has this issue, so currently gcc10 is going to continue to fail. That is being tracked by the following issue, and we will submit a patch for vctrs shortly. https://github.com/r-lib/vctrs/pull/797
 
 ## 0.1.0 Resubmission
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -7,6 +7,10 @@
 
 0 errors | 0 warnings | 0 notes
 
+## 0.1.1 Resubmission
+
+vctrs 0.2.3 is now on CRAN, so the gcc10 warning should no longer occur.
+
 ## 0.1.1 Submission
 
 Fixes a multiple declaration C issue uncovered by CRAN's check under gcc10. We


### PR DESCRIPTION
Closes #63 

Patch release to fix gcc10 compilation warnings.

The other half of this is tracked in https://github.com/r-lib/vctrs/pull/797, for which we should hopefully get a patch release out for quickly