### PR TITLE
Ensure `slide_vec(.ptype = NULL)` is size stable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Collate: 
     'block.R'
     'conditions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # slider (development version)
 
+* All `*_vec()` variants now maintain size stability when auto-simplifying
+  (i.e. when `.ptype = NULL`) (#78).
+
 * `hop()` and its variants no longer place the names of `.x` on the output.
   Because there is no _size_ guarantee on the output, the size of `.x` can
   be different than the size of the output, meaning that the names might not

--- a/R/hop-common.R
+++ b/R/hop-common.R
@@ -1,4 +1,4 @@
-hop_common <- function(x, starts, stops, f_call, ptype, env, type, constrain) {
+hop_common <- function(x, starts, stops, f_call, ptype, env, type, constrain, atomic) {
   x_size <- compute_size(x, type)
 
   check_endpoints_cannot_be_na(starts, ".starts")
@@ -25,7 +25,8 @@ hop_common <- function(x, starts, stops, f_call, ptype, env, type, constrain) {
 
   params <- list(
     type = type,
-    constrain = constrain
+    constrain = constrain,
+    atomic = atomic
   )
 
   .Call(hop_common_impl, x, starts, stops, f_call, ptype, env, params)

--- a/R/hop-index-common.R
+++ b/R/hop-index-common.R
@@ -3,8 +3,9 @@ hop_index_common <- function(x,
                              starts,
                              stops,
                              f_call,
-                             constrain,
                              ptype,
+                             constrain,
+                             atomic,
                              env,
                              type) {
 
@@ -60,6 +61,7 @@ hop_index_common <- function(x,
     window_indices,
     type,
     constrain,
+    atomic,
     size
   )
 }

--- a/R/hop-index.R
+++ b/R/hop-index.R
@@ -105,8 +105,9 @@ hop_index <- function(.x, .i, .starts, .stops, .f, ...) {
     .stops,
     .f,
     ...,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -140,8 +141,9 @@ hop_index_vec <- function(.x,
     .stops,
     .f,
     ...,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -151,23 +153,24 @@ hop_index_vec_simplify <- function(.x,
                                    .stops,
                                    .f,
                                    ...) {
-  out <- hop_index(
+  out <- hop_index_impl(
     .x,
     .i,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
 
 # ------------------------------------------------------------------------------
 
-hop_index_impl <- function(.x, .i, .starts, .stops, .f, ..., .constrain, .ptype) {
+hop_index_impl <- function(.x, .i, .starts, .stops, .f, ..., .ptype, .constrain, .atomic) {
   vec_assert(.x)
 
   .f <- as_function(.f)
@@ -182,8 +185,9 @@ hop_index_impl <- function(.x, .i, .starts, .stops, .f, ..., .constrain, .ptype)
     starts = .starts,
     stops = .stops,
     f_call = f_call,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/hop-index2.R
+++ b/R/hop-index2.R
@@ -74,8 +74,9 @@ hop_index2 <- function(.x, .y, .i, .starts, .stops, .f, ...) {
     .stops,
     .f,
     ...,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -112,8 +113,9 @@ hop_index2_vec <- function(.x,
     .stops,
     .f,
     ...,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -124,24 +126,25 @@ hop_index2_vec_simplify <- function(.x,
                                     .stops,
                                     .f,
                                     ...) {
-  out <- hop_index2(
+  out <- hop_index2_impl(
     .x,
     .y,
     .i,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
 
 # ------------------------------------------------------------------------------
 
-hop_index2_impl <- function(.x, .y, .i, .starts, .stops, .f, ..., .constrain, .ptype) {
+hop_index2_impl <- function(.x, .y, .i, .starts, .stops, .f, ..., .ptype, .constrain, .atomic) {
   vec_assert(.x)
   vec_assert(.y)
 
@@ -162,8 +165,9 @@ hop_index2_impl <- function(.x, .y, .i, .starts, .stops, .f, ..., .constrain, .p
     starts = .starts,
     stops = .stops,
     f_call = f_call,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/hop.R
+++ b/R/hop.R
@@ -103,7 +103,8 @@ hop <- function(.x,
     .f,
     ...,
     .ptype = list(),
-    .constrain = FALSE
+    .constrain = FALSE,
+    .atomic = FALSE
   )
 }
 
@@ -135,7 +136,8 @@ hop_vec <- function(.x,
     .f,
     ...,
     .ptype = .ptype,
-    .constrain = TRUE
+    .constrain = TRUE,
+    .atomic = TRUE
   )
 }
 
@@ -144,15 +146,16 @@ hop_vec_simplify <- function(.x,
                              .stops,
                              .f,
                              ...) {
-  out <- hop(
+  out <- hop_impl(
     .x,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -165,7 +168,8 @@ hop_impl <- function(.x,
                      .f,
                      ...,
                      .ptype,
-                     .constrain) {
+                     .constrain,
+                     .atomic) {
   vec_assert(.x)
 
   .f <- as_function(.f)
@@ -182,6 +186,7 @@ hop_impl <- function(.x,
     ptype = .ptype,
     env = environment(),
     type = type,
-    constrain = .constrain
+    constrain = .constrain,
+    atomic = .atomic
   )
 }

--- a/R/hop2.R
+++ b/R/hop2.R
@@ -70,8 +70,9 @@ hop2 <- function(.x, .y, .starts, .stops, .f, ...) {
     .stops,
     .f,
     ...,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -105,8 +106,9 @@ hop2_vec <- function(.x,
     .stops,
     .f,
     ...,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -116,23 +118,24 @@ hop2_vec_simplify <- function(.x,
                               .stops,
                               .f,
                               ...) {
-  out <- hop2(
+  out <- hop2_impl(
     .x,
     .y,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
 
 # ------------------------------------------------------------------------------
 
-hop2_impl <- function(.x, .y, .starts, .stops, .f, ..., .constrain, .ptype) {
+hop2_impl <- function(.x, .y, .starts, .stops, .f, ..., .ptype, .constrain, .atomic) {
   vec_assert(.x)
   vec_assert(.y)
 
@@ -155,6 +158,7 @@ hop2_impl <- function(.x, .y, .starts, .stops, .f, ..., .constrain, .ptype) {
     ptype = .ptype,
     env = environment(),
     type = type,
-    constrain = .constrain
+    constrain = .constrain,
+    atomic = .atomic
   )
 }

--- a/R/phop-index.R
+++ b/R/phop-index.R
@@ -14,8 +14,9 @@ phop_index <- function(.l,
     .stops,
     .f,
     ...,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -49,8 +50,9 @@ phop_index_vec <- function(.l,
     .stops,
     .f,
     ...,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -60,16 +62,17 @@ phop_index_simplify <- function(.l,
                                 .stops,
                                 .f,
                                 ...) {
-  out <- phop_index(
+  out <- phop_index_impl(
     .l,
     .i,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -82,8 +85,9 @@ phop_index_impl <- function(.l,
                             .stops,
                             .f,
                             ...,
+                            .ptype,
                             .constrain,
-                            .ptype) {
+                            .atomic) {
   check_is_list(.l)
 
   lapply(.l, vec_assert)
@@ -114,8 +118,9 @@ phop_index_impl <- function(.l,
     starts = .starts,
     stops = .stops,
     f_call = f_call,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/phop.R
+++ b/R/phop.R
@@ -12,8 +12,9 @@ phop <- function(.l,
     .stops,
     .f,
     ...,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -44,8 +45,9 @@ phop_vec <- function(.l,
     .stops,
     .f,
     ...,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -54,15 +56,16 @@ phop_simplify <- function(.l,
                           .stops,
                           .f,
                           ...) {
-  out <- phop(
+  out <- phop_impl(
     .l,
     .starts,
     .stops,
     .f,
-    ...
+    ...,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -74,8 +77,9 @@ phop_impl <- function(.l,
                       .stops,
                       .f,
                       ...,
+                      .ptype,
                       .constrain,
-                      .ptype) {
+                      .atomic) {
   check_is_list(.l)
 
   lapply(.l, vec_assert)
@@ -108,6 +112,7 @@ phop_impl <- function(.l,
     ptype = .ptype,
     env = environment(),
     type = type,
-    constrain = .constrain
+    constrain = .constrain,
+    atomic = .atomic
   )
 }

--- a/R/pslide-index.R
+++ b/R/pslide-index.R
@@ -16,8 +16,9 @@ pslide_index <- function(.l,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -54,8 +55,9 @@ pslide_index_vec <- function(.l,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -66,17 +68,18 @@ pslide_index_simplify <- function(.l,
                                   .before,
                                   .after,
                                   .complete) {
-  out <- pslide_index(
+  out <- pslide_index_impl(
     .l,
     .i,
     .f,
     ...,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -224,8 +227,9 @@ pslide_index_impl <- function(.l,
                               .before,
                               .after,
                               .complete,
+                              .ptype,
                               .constrain,
-                              .ptype) {
+                              .atomic) {
   check_is_list(.l)
 
   lapply(.l, vec_assert)
@@ -257,8 +261,9 @@ pslide_index_impl <- function(.l,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/pslide-period.R
+++ b/R/pslide-period.R
@@ -102,8 +102,6 @@ pslide_period_vec_simplify <- function(.l,
     .atomic = TRUE
   )
 
-  check_all_size_one(out)
-
   vec_simplify(out)
 }
 

--- a/R/pslide-period.R
+++ b/R/pslide-period.R
@@ -22,8 +22,9 @@ pslide_period <- function(.l,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -69,8 +70,9 @@ pslide_period_vec <- function(.l,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -84,7 +86,7 @@ pslide_period_vec_simplify <- function(.l,
                                        .before,
                                        .after,
                                        .complete) {
-  out <- pslide_period(
+  out <- pslide_period_impl(
     .l,
     .i,
     .period,
@@ -94,7 +96,10 @@ pslide_period_vec_simplify <- function(.l,
     .origin = .origin,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
 
   check_all_size_one(out)
@@ -282,8 +287,9 @@ pslide_period_impl <- function(.l,
                                .before,
                                .after,
                                .complete,
+                               .ptype,
                                .constrain,
-                               .ptype) {
+                               .atomic) {
   check_is_list(.l)
 
   lapply(.l, vec_assert)
@@ -318,8 +324,9 @@ pslide_period_impl <- function(.l,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/pslide.R
+++ b/R/pslide.R
@@ -17,7 +17,8 @@ pslide <- function(.l,
     .step = .step,
     .complete = .complete,
     .ptype = list(),
-    .constrain = FALSE
+    .constrain = FALSE,
+    .atomic = FALSE
   )
 }
 
@@ -55,7 +56,8 @@ pslide_vec <- function(.l,
     .step = .step,
     .complete = .complete,
     .ptype = .ptype,
-    .constrain = TRUE
+    .constrain = TRUE,
+    .atomic = TRUE
   )
 }
 
@@ -66,17 +68,18 @@ pslide_vec_simplify <- function(.l,
                                 .after,
                                 .step,
                                 .complete) {
-  out <- pslide(
+  out <- pslide_impl(
     .l,
     .f,
     ...,
     .before = .before,
     .after = .after,
     .step = .step,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -225,7 +228,8 @@ pslide_impl <- function(.l,
                         .step,
                         .complete,
                         .ptype,
-                        .constrain) {
+                        .constrain,
+                        .atomic) {
   check_is_list(.l)
 
   lapply(.l, vec_assert)
@@ -258,7 +262,8 @@ pslide_impl <- function(.l,
     .before,
     .after,
     .step,
-    .complete
+    .complete,
+    .atomic
   )
 
   slide_common(

--- a/R/pslide.R
+++ b/R/pslide.R
@@ -259,11 +259,11 @@ pslide_impl <- function(.l,
   params <- list(
     type,
     .constrain,
+    .atomic,
     .before,
     .after,
     .step,
-    .complete,
-    .atomic
+    .complete
   )
 
   slide_common(

--- a/R/slide-index-common.R
+++ b/R/slide-index-common.R
@@ -4,8 +4,9 @@ slide_index_common <- function(x,
                                before,
                                after,
                                complete,
-                               constrain,
                                ptype,
+                               constrain,
+                               atomic,
                                env,
                                type) {
   vec_assert(i)
@@ -54,6 +55,7 @@ slide_index_common <- function(x,
     indices,
     type,
     constrain,
+    atomic,
     x_size,
     complete
   )

--- a/R/slide-index.R
+++ b/R/slide-index.R
@@ -126,8 +126,9 @@ slide_index <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -164,8 +165,9 @@ slide_index_vec <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -176,17 +178,18 @@ slide_index_simplify <- function(.x,
                                  .before,
                                  .after,
                                  .complete) {
-  out <- slide_index(
+  out <- slide_index_impl(
     .x,
     .i,
     .f,
     ...,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -334,8 +337,9 @@ slide_index_impl <- function(.x,
                              .before,
                              .after,
                              .complete,
+                             .ptype,
                              .constrain,
-                             .ptype) {
+                             .atomic) {
   vec_assert(.x)
 
   .f <- as_function(.f)
@@ -351,8 +355,9 @@ slide_index_impl <- function(.x,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/slide-index2.R
+++ b/R/slide-index2.R
@@ -79,8 +79,9 @@ slide_index2 <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -121,7 +122,8 @@ slide_index2_vec <- function(.x,
     .after = .after,
     .complete = .complete,
     .ptype = .ptype,
-    .constrain = TRUE
+    .constrain = TRUE,
+    .atomic = TRUE
   )
 }
 
@@ -133,7 +135,7 @@ slide_index2_vec_simplify <- function(.x,
                                       .before,
                                       .after,
                                       .complete) {
-  out <- slide_index2(
+  out <- slide_index2_impl(
     .x,
     .y,
     .i,
@@ -141,10 +143,11 @@ slide_index2_vec_simplify <- function(.x,
     ...,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -305,8 +308,9 @@ slide_index2_impl <- function(.x,
                               .before,
                               .after,
                               .complete,
+                              .ptype,
                               .constrain,
-                              .ptype) {
+                              .atomic) {
   vec_assert(.x)
   vec_assert(.y)
 
@@ -326,8 +330,9 @@ slide_index2_impl <- function(.x,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/slide-period-common.R
+++ b/R/slide-period-common.R
@@ -7,8 +7,9 @@ slide_period_common <- function(x,
                                 before,
                                 after,
                                 complete,
-                                constrain,
                                 ptype,
+                                constrain,
+                                atomic,
                                 env,
                                 type) {
   check_index_incompatible_type(i, ".i")
@@ -56,8 +57,9 @@ slide_period_common <- function(x,
     starts = starts,
     stops = stops,
     f_call = f_call,
-    constrain = constrain,
     ptype = ptype,
+    constrain = constrain,
+    atomic = atomic,
     env = env,
     type = type
   )

--- a/R/slide-period.R
+++ b/R/slide-period.R
@@ -119,8 +119,9 @@ slide_period <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -166,8 +167,9 @@ slide_period_vec <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -181,7 +183,7 @@ slide_period_simplify <- function(.x,
                                   .before,
                                   .after,
                                   .complete) {
-  out <- slide_period(
+  out <- slide_period_impl(
     .x,
     .i,
     .period,
@@ -191,10 +193,11 @@ slide_period_simplify <- function(.x,
     .origin = .origin,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -379,8 +382,9 @@ slide_period_impl <- function(.x,
                               .before,
                               .after,
                               .complete,
+                              .ptype,
                               .constrain,
-                              .ptype) {
+                              .atomic) {
   vec_assert(.x)
 
   .f <- as_function(.f)
@@ -399,8 +403,9 @@ slide_period_impl <- function(.x,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/slide-period2.R
+++ b/R/slide-period2.R
@@ -92,8 +92,9 @@ slide_period2 <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = list(),
     .constrain = FALSE,
-    .ptype = list()
+    .atomic = FALSE
   )
 }
 
@@ -142,8 +143,9 @@ slide_period2_vec <- function(.x,
     .before = .before,
     .after = .after,
     .complete = .complete,
+    .ptype = .ptype,
     .constrain = TRUE,
-    .ptype = .ptype
+    .atomic = TRUE
   )
 }
 
@@ -158,7 +160,7 @@ slide_period2_vec_simplify <- function(.x,
                                        .before,
                                        .after,
                                        .complete) {
-  out <- slide_period2(
+  out <- slide_period2_impl(
     .x,
     .y,
     .i,
@@ -169,10 +171,11 @@ slide_period2_vec_simplify <- function(.x,
     .origin = .origin,
     .before = .before,
     .after = .after,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -370,8 +373,9 @@ slide_period2_impl <- function(.x,
                                .before,
                                .after,
                                .complete,
+                               .ptype,
                                .constrain,
-                               .ptype) {
+                               .atomic) {
   vec_assert(.x)
   vec_assert(.y)
 
@@ -396,8 +400,9 @@ slide_period2_impl <- function(.x,
     before = .before,
     after = .after,
     complete = .complete,
-    constrain = .constrain,
     ptype = .ptype,
+    constrain = .constrain,
+    atomic = .atomic,
     env = environment(),
     type = type
   )

--- a/R/slide.R
+++ b/R/slide.R
@@ -207,7 +207,8 @@ slide <- function(.x,
     .step = .step,
     .complete = .complete,
     .ptype = list(),
-    .constrain = FALSE
+    .constrain = FALSE,
+    .atomic = FALSE
   )
 }
 
@@ -245,7 +246,8 @@ slide_vec <- function(.x,
     .step = .step,
     .complete = .complete,
     .ptype = .ptype,
-    .constrain = TRUE
+    .constrain = TRUE,
+    .atomic = TRUE
   )
 }
 
@@ -256,17 +258,18 @@ slide_vec_simplify <- function(.x,
                                .after,
                                .step,
                                .complete) {
-  out <- slide(
+  out <- slide_impl(
     .x,
     .f,
     ...,
     .before = .before,
     .after = .after,
     .step = .step,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -415,6 +418,7 @@ slide_impl <- function(.x,
                        .step,
                        .complete,
                        .constrain,
+                       .atomic,
                        .ptype) {
   vec_assert(.x)
 
@@ -430,7 +434,8 @@ slide_impl <- function(.x,
     before = .before,
     after = .after,
     step = .step,
-    complete = .complete
+    complete = .complete,
+    atomic = .atomic
   )
 
   slide_common(

--- a/R/slide.R
+++ b/R/slide.R
@@ -431,11 +431,11 @@ slide_impl <- function(.x,
   params <- list(
     type = type,
     constrain = .constrain,
+    atomic = .atomic,
     before = .before,
     after = .after,
     step = .step,
-    complete = .complete,
-    atomic = .atomic
+    complete = .complete
   )
 
   slide_common(

--- a/R/slide.R
+++ b/R/slide.R
@@ -417,9 +417,9 @@ slide_impl <- function(.x,
                        .after,
                        .step,
                        .complete,
+                       .ptype,
                        .constrain,
-                       .atomic,
-                       .ptype) {
+                       .atomic) {
   vec_assert(.x)
 
   .f <- as_function(.f)

--- a/R/slide2.R
+++ b/R/slide2.R
@@ -93,7 +93,8 @@ slide2 <- function(.x,
     .step = .step,
     .complete = .complete,
     .ptype = list(),
-    .constrain = FALSE
+    .constrain = FALSE,
+    .atomic = FALSE
   )
 }
 
@@ -134,7 +135,8 @@ slide2_vec <- function(.x,
     .step = .step,
     .complete = .complete,
     .ptype = .ptype,
-    .constrain = TRUE
+    .constrain = TRUE,
+    .atomic = TRUE
   )
 }
 
@@ -146,7 +148,7 @@ slide2_vec_simplify <- function(.x,
                                 .after,
                                 .step,
                                 .complete) {
-  out <- slide2(
+  out <- slide2_impl(
     .x,
     .y,
     .f,
@@ -154,10 +156,11 @@ slide2_vec_simplify <- function(.x,
     .before = .before,
     .after = .after,
     .step = .step,
-    .complete = .complete
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
   )
-
-  check_all_size_one(out)
 
   vec_simplify(out)
 }
@@ -319,7 +322,8 @@ slide2_impl <- function(.x,
                         .step,
                         .complete,
                         .ptype,
-                        .constrain) {
+                        .constrain,
+                        .atomic) {
   vec_assert(.x)
   vec_assert(.y)
 
@@ -340,7 +344,8 @@ slide2_impl <- function(.x,
     .before,
     .after,
     .step,
-    .complete
+    .complete,
+    .atomic
   )
 
   slide_common(

--- a/R/slide2.R
+++ b/R/slide2.R
@@ -341,11 +341,11 @@ slide2_impl <- function(.x,
   params <- list(
     type,
     .constrain,
+    .atomic,
     .before,
     .after,
     .step,
-    .complete,
-    .atomic
+    .complete
   )
 
   slide_common(

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,23 +21,6 @@ is_unbounded <- function(x) {
   }
 }
 
-check_all_size_one <- function(out) {
-  if (vec_size(out) == 0L) {
-    return(invisible(out))
-  }
-
-  size <- vec_size_common(!!!out)
-
-  if (size != 1L) {
-    sizes <- vapply(out, vec_size, integer(1))
-    iteration <- which(sizes != 1L)[[1L]]
-    bad_size <- sizes[[iteration]]
-    stop_not_all_size_one(iteration, bad_size)
-  }
-
-  invisible(out)
-}
-
 check_is_list <- function(.l) {
   if (!is.list(.l)) {
     abort(paste0("`.l` must be a list, not ", vec_ptype_full(.l), "."))

--- a/src/init.c
+++ b/src/init.c
@@ -7,7 +7,7 @@
 extern SEXP slide_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP hop_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP hop_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP hop_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP slider_block(SEXP, SEXP, SEXP);
 extern SEXP slider_compute_from(SEXP, SEXP, SEXP, SEXP);
 extern SEXP slider_compute_to(SEXP, SEXP, SEXP, SEXP);
@@ -21,7 +21,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"slide_common_impl",         (DL_FUNC) &slide_common_impl, 5},
   {"hop_common_impl",           (DL_FUNC) &hop_common_impl, 7},
   {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 13},
-  {"hop_index_common_impl",     (DL_FUNC) &hop_index_common_impl, 11},
+  {"hop_index_common_impl",     (DL_FUNC) &hop_index_common_impl, 12},
   {"slider_block",              (DL_FUNC) &slider_block, 3},
   {"slider_compute_from",       (DL_FUNC) &slider_compute_from, 4},
   {"slider_compute_to",         (DL_FUNC) &slider_compute_to, 4},

--- a/src/init.c
+++ b/src/init.c
@@ -6,7 +6,7 @@
 /* .Call calls */
 extern SEXP slide_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP hop_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP slide_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP hop_index_common_impl(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP slider_block(SEXP, SEXP, SEXP);
 extern SEXP slider_compute_from(SEXP, SEXP, SEXP, SEXP);
@@ -20,7 +20,7 @@ SEXP slider_init(SEXP);
 static const R_CallMethodDef CallEntries[] = {
   {"slide_common_impl",         (DL_FUNC) &slide_common_impl, 5},
   {"hop_common_impl",           (DL_FUNC) &hop_common_impl, 7},
-  {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 12},
+  {"slide_index_common_impl",   (DL_FUNC) &slide_index_common_impl, 13},
   {"hop_index_common_impl",     (DL_FUNC) &hop_index_common_impl, 11},
   {"slider_block",              (DL_FUNC) &slider_block, 3},
   {"slider_compute_from",       (DL_FUNC) &slider_compute_from, 4},

--- a/src/params.c
+++ b/src/params.c
@@ -117,6 +117,11 @@ int pull_complete(SEXP params) {
   return r_scalar_lgl_get(complete);
 }
 
+// [[ include("params.h") ]]
+bool pull_atomic(SEXP params) {
+  return r_scalar_lgl_get(r_lst_get(params, 6));
+}
+
 // -----------------------------------------------------------------------------
 
 // [[ include("params.h") ]]

--- a/src/params.c
+++ b/src/params.c
@@ -63,8 +63,13 @@ bool pull_constrain(SEXP params) {
 }
 
 // [[ include("params.h") ]]
+bool pull_atomic(SEXP params) {
+  return r_scalar_lgl_get(r_lst_get(params, 2));
+}
+
+// [[ include("params.h") ]]
 int pull_before(SEXP params, bool* before_unbounded) {
-  SEXP before = r_lst_get(params, 2);
+  SEXP before = r_lst_get(params, 3);
 
   check_scalar(before, strings_dot_before);
 
@@ -80,7 +85,7 @@ int pull_before(SEXP params, bool* before_unbounded) {
 
 // [[ include("params.h") ]]
 int pull_after(SEXP params, bool* after_unbounded) {
-  SEXP after = r_lst_get(params, 3);
+  SEXP after = r_lst_get(params, 4);
 
   check_scalar(after, strings_dot_after);
 
@@ -96,7 +101,7 @@ int pull_after(SEXP params, bool* after_unbounded) {
 
 // [[ include("params.h") ]]
 int pull_step(SEXP params) {
-  SEXP step_ = r_lst_get(params, 4);
+  SEXP step_ = r_lst_get(params, 5);
   step_ = PROTECT(check_scalar_int(step_, strings_dot_step));
 
   int step = r_scalar_int_get(step_);
@@ -111,15 +116,10 @@ int pull_step(SEXP params) {
 
 // [[ include("params.h") ]]
 int pull_complete(SEXP params) {
-  SEXP complete = r_lst_get(params, 5);
+  SEXP complete = r_lst_get(params, 6);
   complete = PROTECT(check_scalar_lgl(complete, strings_dot_complete));
   UNPROTECT(1);
   return r_scalar_lgl_get(complete);
-}
-
-// [[ include("params.h") ]]
-bool pull_atomic(SEXP params) {
-  return r_scalar_lgl_get(r_lst_get(params, 6));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/params.h
+++ b/src/params.h
@@ -5,11 +5,11 @@
 
 int pull_type(SEXP params);
 bool pull_constrain(SEXP params);
+bool pull_atomic(SEXP params);
 int pull_before(SEXP params, bool* before_unbounded);
 int pull_after(SEXP params, bool* after_unbounded);
 int pull_step(SEXP params);
 int pull_complete(SEXP params);
-bool pull_atomic(SEXP params);
 
 void check_double_negativeness(int before, int after, bool before_positive, bool after_positive);
 void check_after_negativeness(int after, int before, bool after_positive, bool before_unbounded);

--- a/src/params.h
+++ b/src/params.h
@@ -9,6 +9,7 @@ int pull_before(SEXP params, bool* before_unbounded);
 int pull_after(SEXP params, bool* after_unbounded);
 int pull_step(SEXP params);
 int pull_complete(SEXP params);
+bool pull_atomic(SEXP params);
 
 void check_double_negativeness(int before, int after, bool before_positive, bool after_positive);
 void check_after_negativeness(int after, int before, bool after_positive, bool before_unbounded);

--- a/src/slide.c
+++ b/src/slide.c
@@ -12,29 +12,29 @@ SEXP slide_common_impl(SEXP x,
                        SEXP env,
                        SEXP params) {
 
-  int type = pull_type(params);
+  const int type = pull_type(params);
 
-  int size = compute_size(x, type);
+  const int size = compute_size(x, type);
 
   // Bail early if inputs are size 0
   if (size == 0) {
     return vec_init(ptype, 0);
   }
 
-  int force = compute_force(type);
+  const int force = compute_force(type);
 
   bool before_unbounded = false;
   bool after_unbounded = false;
 
-  bool constrain = pull_constrain(params);
-  int before = pull_before(params, &before_unbounded);
-  int after = pull_after(params, &after_unbounded);
-  int step = pull_step(params);
-  bool complete = pull_complete(params);
-  bool atomic = pull_atomic(params);
+  const bool constrain = pull_constrain(params);
+  const int before = pull_before(params, &before_unbounded);
+  const int after = pull_after(params, &after_unbounded);
+  const int step = pull_step(params);
+  const bool complete = pull_complete(params);
+  const bool atomic = pull_atomic(params);
 
-  bool before_positive = before >= 0;
-  bool after_positive = after >= 0;
+  const bool before_positive = before >= 0;
+  const bool after_positive = after >= 0;
 
   check_double_negativeness(before, after, before_positive, after_positive);
   check_before_negativeness(before, after, before_positive, after_unbounded);

--- a/src/slide.c
+++ b/src/slide.c
@@ -31,6 +31,7 @@ SEXP slide_common_impl(SEXP x,
   int after = pull_after(params, &after_unbounded);
   int step = pull_step(params);
   bool complete = pull_complete(params);
+  bool atomic = pull_atomic(params);
 
   bool before_positive = before >= 0;
   bool after_positive = after >= 0;
@@ -96,6 +97,13 @@ SEXP slide_common_impl(SEXP x,
   out = vec_init(out, size);
   REPROTECT(out, out_prot_idx);
 
+  // Initialize with `NA`, not `NULL`, for size stability when auto-simplifying
+  if (atomic && !constrain) {
+    for (R_len_t i = 0; i < size; ++i) {
+      SET_VECTOR_ELT(out, i, slider_shared_na_lgl);
+    }
+  }
+
   // The indices to slice x with
   SEXP window = PROTECT(compact_seq(0, 0, true));
   int* p_window = INTEGER(window);
@@ -134,15 +142,15 @@ SEXP slide_common_impl(SEXP x,
 #endif
     REPROTECT(elt, elt_prot_idx);
 
+    if (atomic && vec_size(elt) != 1) {
+      stop_not_all_size_one(i + 1, vec_size(elt));
+    }
+
     if (constrain) {
+      *p_index = i + 1;
+
       elt = vec_cast(elt, ptype);
       REPROTECT(elt, elt_prot_idx);
-
-      if (vec_size(elt) != 1) {
-        stop_not_all_size_one(i + 1, vec_size(elt));
-      }
-
-      *p_index = i + 1;
 
       out = vec_proxy_assign(out, index, elt);
       REPROTECT(out, out_prot_idx);

--- a/src/slide.c
+++ b/src/slide.c
@@ -27,11 +27,11 @@ SEXP slide_common_impl(SEXP x,
   bool after_unbounded = false;
 
   const bool constrain = pull_constrain(params);
+  const bool atomic = pull_atomic(params);
   const int before = pull_before(params, &before_unbounded);
   const int after = pull_after(params, &after_unbounded);
   const int step = pull_step(params);
   const bool complete = pull_complete(params);
-  const bool atomic = pull_atomic(params);
 
   const bool before_positive = before >= 0;
   const bool after_positive = after >= 0;

--- a/src/utils.c
+++ b/src/utils.c
@@ -15,6 +15,8 @@ SEXP syms_dot_l = NULL;
 SEXP slider_shared_empty_lgl = NULL;
 SEXP slider_shared_empty_int = NULL;
 
+SEXP slider_shared_na_lgl = NULL;
+
 SEXP slider_ns_env = NULL;
 
 // -----------------------------------------------------------------------------
@@ -206,4 +208,9 @@ void slider_init_utils(SEXP ns) {
   slider_shared_empty_int = Rf_allocVector(INTSXP, 0);
   R_PreserveObject(slider_shared_empty_int);
   MARK_NOT_MUTABLE(slider_shared_empty_int);
+
+  slider_shared_na_lgl = Rf_allocVector(LGLSXP, 1);
+  R_PreserveObject(slider_shared_na_lgl);
+  LOGICAL(slider_shared_na_lgl)[0] = NA_LOGICAL;
+  MARK_NOT_MUTABLE(slider_shared_na_lgl);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -43,6 +43,8 @@ extern SEXP syms_dot_l;
 extern SEXP slider_shared_empty_lgl;
 extern SEXP slider_shared_empty_int;
 
+extern SEXP slider_shared_na_lgl;
+
 extern SEXP slider_ns_env;
 
 void stop_not_all_size_one(int iteration, int size);

--- a/tests/testthat/test-hop-index-vec.R
+++ b/tests/testthat/test-hop-index-vec.R
@@ -51,6 +51,10 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     hop_index_vec(1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 2, not 1."
   )
+  expect_error(
+    hop_index_vec(1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
 })
 
 test_that("`.ptype = NULL` returns `NULL` with size 0 `.starts` / `.stops`", {

--- a/tests/testthat/test-hop-index2-vec.R
+++ b/tests/testthat/test-hop-index2-vec.R
@@ -20,3 +20,17 @@ test_that("hop_index2_vec() errors if it can't simplify", {
     class = "vctrs_error_incompatible_type"
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` validates that element lengths are 1", {
+  expect_error(
+    hop_index2_vec(1:2, 1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 2, not 1."
+  )
+  expect_error(
+    hop_index2_vec(1:2, 1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
+})

--- a/tests/testthat/test-hop-vec.R
+++ b/tests/testthat/test-hop-vec.R
@@ -51,6 +51,10 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     hop_vec(1:2, 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 2, not 1."
   )
+  expect_error(
+    hop_vec(1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
 })
 
 test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {

--- a/tests/testthat/test-hop2-vec.R
+++ b/tests/testthat/test-hop2-vec.R
@@ -20,3 +20,17 @@ test_that("hop2_vec() errors if it can't simplify", {
     class = "vctrs_error_incompatible_type"
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` validates that element lengths are 1", {
+  expect_error(
+    hop2_vec(1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 2, not 1."
+  )
+  expect_error(
+    hop2_vec(1:2, 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
+})

--- a/tests/testthat/test-phop-index-vec.R
+++ b/tests/testthat/test-phop-index-vec.R
@@ -33,3 +33,17 @@ test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns 
     c(NA_integer_, NA_integer_)
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` validates that element lengths are 1", {
+  expect_error(
+    phop_index_vec(list(1:2, 1:2), 1:2, 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 2, not 1."
+  )
+  expect_error(
+    phop_index_vec(list(1:2, 1:2), 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
+})

--- a/tests/testthat/test-phop-vec.R
+++ b/tests/testthat/test-phop-vec.R
@@ -20,3 +20,17 @@ test_that("phop_vec() errors if it can't simplify", {
     class = "vctrs_error_incompatible_type"
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` validates that element lengths are 1", {
+  expect_error(
+    phop_vec(list(1:2, 1:2), 1:2, 1:2, ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 2, not 1."
+  )
+  expect_error(
+    phop_vec(list(1:2, 1:2), 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
+})

--- a/tests/testthat/test-pslide-index-vec.R
+++ b/tests/testthat/test-pslide-index-vec.R
@@ -95,3 +95,10 @@ test_that("pslide_index_dfc() works", {
     )
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(pslide_index_vec(list(1:4, 1:4), 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})

--- a/tests/testthat/test-pslide-period-vec.R
+++ b/tests/testthat/test-pslide-period-vec.R
@@ -51,6 +51,10 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     pslide_period_vec(list(1:2, 1:2), new_date(0:1), "day", ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 2, not 1."
   )
+  expect_error(
+    pslide_period_vec(list(1:2, 1:2), new_date(0:1), "day", ~if(.x == 1L) {NULL} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
 })
 
 test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {

--- a/tests/testthat/test-pslide-vec.R
+++ b/tests/testthat/test-pslide-vec.R
@@ -89,3 +89,11 @@ test_that("pslide_dfc() works", {
     )
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(pslide_vec(list(1:4, 1:4), ~.x, .step = 2), 4)
+  expect_length(pslide_vec(list(1:4, 1:4), ~1, .before = 1, .complete = TRUE), 4)
+})

--- a/tests/testthat/test-slide-index-vec.R
+++ b/tests/testthat/test-slide-index-vec.R
@@ -57,6 +57,10 @@ test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {
   expect_equal(slide_index_vec(integer(), integer(), ~.x, .ptype = NULL), NULL)
 })
 
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(slide_index_vec(1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})
+
 test_that(".ptypes with a vec_proxy() are restored to original type", {
   expect_is(
     slide_index_vec(Sys.Date() + 1:5, 1:5, ~.x, .ptype = as.POSIXlt(Sys.Date())),

--- a/tests/testthat/test-slide-index2-vec.R
+++ b/tests/testthat/test-slide-index2-vec.R
@@ -85,3 +85,10 @@ test_that("slide_index2_dfc() works", {
     slide_dfc(x, ~data.frame(x = .x), .before = 1)
   )
 })
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(slide_index2_vec(1:4, 1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})

--- a/tests/testthat/test-slide-period-vec.R
+++ b/tests/testthat/test-slide-period-vec.R
@@ -51,6 +51,10 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     slide_period_vec(1:2, new_date(0:1), "day", ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 2, not 1."
   )
+  expect_error(
+    slide_period_vec(1:2, new_date(0:1), "day", ~if(.x == 1L) {NULL} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
 })
 
 test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {

--- a/tests/testthat/test-slide-period2-vec.R
+++ b/tests/testthat/test-slide-period2-vec.R
@@ -51,6 +51,10 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     slide_period2_vec(1:2, 1:2, new_date(0:1), "day", ~if(.x == 1L) {1:2} else {1}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 2, not 1."
   )
+  expect_error(
+    slide_period2_vec(1:2, 1:2, new_date(0:1), "day", ~if(.x == 1L) {NULL} else {1}, .ptype = NULL),
+    "In iteration 1, the result of `.f` had size 0, not 1."
+  )
 })
 
 test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -57,6 +57,11 @@ test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {
   expect_equal(slide_vec(integer(), ~.x, .ptype = NULL), NULL)
 })
 
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(slide_vec(1:4, ~.x, .step = 2), 4)
+  expect_length(slide_vec(1:4, ~1, .before = 1, .complete = TRUE), 4)
+})
+
 test_that(".ptypes with a vec_proxy() are restored to original type", {
   expect_is(
     slide_vec(Sys.Date() + 1:5, ~.x, .ptype = as.POSIXlt(Sys.Date())),

--- a/tests/testthat/test-slide2-vec.R
+++ b/tests/testthat/test-slide2-vec.R
@@ -89,3 +89,12 @@ test_that("slide2_dfc() works", {
     )
   )
 })
+
+
+# ------------------------------------------------------------------------------
+# .ptype
+
+test_that("`.ptype = NULL` is size stable (#78)", {
+  expect_length(slide2_vec(1:4, 1:4, ~.x, .step = 2), 4)
+  expect_length(slide2_vec(1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})


### PR DESCRIPTION
Closes #78 

This PR ensures that `slide_vec(.ptype = NULL)` is always size stable. The problem was that we used `slide()` before simplifying, which returns a list where each element can have any size. Because there is no size restriction, it is appropriate for `NULL` to be the missing value here. This causes a problem when simplifying, as the `NULL`s are compacted out in `vec_c()`.

What we really needed to do is call a variant of `slide()` that returns an _atomic list_, i.e., one where each element is guaranteed to have size 1. We sort of tried to do this already by enforcing a `check_all_size_one()` check, but this was wrong because it allowed `NULL` values to slip through without error.

We have now moved that size check to C, and directly check `vec_size(elt) != 1`.

Additionally, the "atomic list" variant of `slide()` places a size 1 logical unspecified `NA` in the missing value slots rather than a `NULL`. This ensures that when `vec_c()` is called, those `NA`s are coerced to the right type (because they are unspecified) and are represented as a size 1 element of whatever the common type is, enforcing size stability.