### PR TITLE
Force `*_vec()` variants through `vec_unchop()`

### DIFF
--- a/R/hop-index.R
+++ b/R/hop-index.R
@@ -120,39 +120,6 @@ hop_index_vec <- function(.x,
                           .f,
                           ...,
                           .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- hop_index_vec_simplify(
-      .x,
-      .i,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  hop_index_impl(
-    .x,
-    .i,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-hop_index_vec_simplify <- function(.x,
-                                   .i,
-                                   .starts,
-                                   .stops,
-                                   .f,
-                                   ...) {
   out <- hop_index_impl(
     .x,
     .i,
@@ -165,7 +132,7 @@ hop_index_vec_simplify <- function(.x,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/hop-index2.R
+++ b/R/hop-index2.R
@@ -90,42 +90,6 @@ hop_index2_vec <- function(.x,
                            .f,
                            ...,
                            .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- hop_index2_vec_simplify(
-      .x,
-      .y,
-      .i,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  hop_index2_impl(
-    .x,
-    .y,
-    .i,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-hop_index2_vec_simplify <- function(.x,
-                                    .y,
-                                    .i,
-                                    .starts,
-                                    .stops,
-                                    .f,
-                                    ...) {
   out <- hop_index2_impl(
     .x,
     .y,
@@ -139,7 +103,7 @@ hop_index2_vec_simplify <- function(.x,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/hop.R
+++ b/R/hop.R
@@ -116,36 +116,6 @@ hop_vec <- function(.x,
                     .f,
                     ...,
                     .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- hop_vec_simplify(
-      .x,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  hop_impl(
-    .x,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-hop_vec_simplify <- function(.x,
-                             .starts,
-                             .stops,
-                             .f,
-                             ...) {
   out <- hop_impl(
     .x,
     .starts,
@@ -157,7 +127,7 @@ hop_vec_simplify <- function(.x,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/hop2.R
+++ b/R/hop2.R
@@ -85,39 +85,6 @@ hop2_vec <- function(.x,
                      .f,
                      ...,
                      .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- hop2_vec_simplify(
-      .x,
-      .y,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  hop2_impl(
-    .x,
-    .y,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-hop2_vec_simplify <- function(.x,
-                              .y,
-                              .starts,
-                              .stops,
-                              .f,
-                              ...) {
   out <- hop2_impl(
     .x,
     .y,
@@ -130,7 +97,7 @@ hop2_vec_simplify <- function(.x,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/phop-index.R
+++ b/R/phop-index.R
@@ -29,39 +29,6 @@ phop_index_vec <- function(.l,
                            .f,
                            ...,
                            .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- phop_index_simplify(
-      .l,
-      .i,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  phop_index_impl(
-    .l,
-    .i,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-phop_index_simplify <- function(.l,
-                                .i,
-                                .starts,
-                                .stops,
-                                .f,
-                                ...) {
   out <- phop_index_impl(
     .l,
     .i,
@@ -74,7 +41,7 @@ phop_index_simplify <- function(.l,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/phop.R
+++ b/R/phop.R
@@ -26,36 +26,6 @@ phop_vec <- function(.l,
                      .f,
                      ...,
                      .ptype = NULL) {
-
-  if (is.null(.ptype)) {
-    out <- phop_simplify(
-      .l,
-      .starts,
-      .stops,
-      .f,
-      ...
-    )
-
-    return(out)
-  }
-
-  phop_impl(
-    .l,
-    .starts,
-    .stops,
-    .f,
-    ...,
-    .ptype = .ptype,
-    .constrain = TRUE,
-    .atomic = TRUE
-  )
-}
-
-phop_simplify <- function(.l,
-                          .starts,
-                          .stops,
-                          .f,
-                          ...) {
   out <- phop_impl(
     .l,
     .starts,
@@ -67,7 +37,7 @@ phop_simplify <- function(.l,
     .atomic = TRUE
   )
 
-  vec_simplify(out)
+  vec_simplify(out, .ptype)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/pslide-index.R
+++ b/R/pslide-index.R
@@ -32,21 +32,30 @@ pslide_index_vec <- function(.l,
                              .after = 0L,
                              .complete = FALSE,
                              .ptype = NULL) {
+  out <- pslide_index_impl(
+    .l,
+    .i,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- pslide_index_simplify(
-      .l,
-      .i,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+pslide_index_vec_direct <- function(.l,
+                                    .i,
+                                    .f,
+                                    ...,
+                                    .before,
+                                    .after,
+                                    .complete,
+                                    .ptype) {
   pslide_index_impl(
     .l,
     .i,
@@ -61,29 +70,6 @@ pslide_index_vec <- function(.l,
   )
 }
 
-pslide_index_simplify <- function(.l,
-                                  .i,
-                                  .f,
-                                  ...,
-                                  .before,
-                                  .after,
-                                  .complete) {
-  out <- pslide_index_impl(
-    .l,
-    .i,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_index2
 #' @export
 pslide_index_dbl <- function(.l,
@@ -93,7 +79,7 @@ pslide_index_dbl <- function(.l,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  pslide_index_vec(
+  pslide_index_vec_direct(
     .l,
     .i,
     .f,
@@ -114,7 +100,7 @@ pslide_index_int <- function(.l,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  pslide_index_vec(
+  pslide_index_vec_direct(
     .l,
     .i,
     .f,
@@ -135,7 +121,7 @@ pslide_index_lgl <- function(.l,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  pslide_index_vec(
+  pslide_index_vec_direct(
     .l,
     .i,
     .f,
@@ -156,7 +142,7 @@ pslide_index_chr <- function(.l,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  pslide_index_vec(
+  pslide_index_vec_direct(
     .l,
     .i,
     .f,

--- a/R/pslide-period.R
+++ b/R/pslide-period.R
@@ -41,24 +41,36 @@ pslide_period_vec <- function(.l,
                               .after = 0L,
                               .complete = FALSE,
                               .ptype = NULL) {
+  out <- pslide_period_impl(
+    .l,
+    .i,
+    .period,
+    .f,
+    ...,
+    .every = .every,
+    .origin = .origin,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- pslide_period_vec_simplify(
-      .l,
-      .i,
-      .period,
-      .f,
-      ...,
-      .every = .every,
-      .origin = .origin,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+pslide_period_vec_direct <- function(.l,
+                                     .i,
+                                     .period,
+                                     .f,
+                                     ...,
+                                     .every,
+                                     .origin,
+                                     .before,
+                                     .after,
+                                     .complete,
+                                     .ptype) {
   pslide_period_impl(
     .l,
     .i,
@@ -76,35 +88,6 @@ pslide_period_vec <- function(.l,
   )
 }
 
-pslide_period_vec_simplify <- function(.l,
-                                       .i,
-                                       .period,
-                                       .f,
-                                       ...,
-                                       .every,
-                                       .origin,
-                                       .before,
-                                       .after,
-                                       .complete) {
-  out <- pslide_period_impl(
-    .l,
-    .i,
-    .period,
-    .f,
-    ...,
-    .every = .every,
-    .origin = .origin,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_period2
 #' @export
 pslide_period_dbl <- function(.l,
@@ -117,7 +100,7 @@ pslide_period_dbl <- function(.l,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  pslide_period_vec(
+  pslide_period_vec_direct(
     .l,
     .i,
     .period,
@@ -144,7 +127,7 @@ pslide_period_int <- function(.l,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  pslide_period_vec(
+  pslide_period_vec_direct(
     .l,
     .i,
     .period,
@@ -171,7 +154,7 @@ pslide_period_lgl <- function(.l,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  pslide_period_vec(
+  pslide_period_vec_direct(
     .l,
     .i,
     .period,
@@ -198,7 +181,7 @@ pslide_period_chr <- function(.l,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  pslide_period_vec(
+  pslide_period_vec_direct(
     .l,
     .i,
     .period,

--- a/R/pslide.R
+++ b/R/pslide.R
@@ -32,21 +32,30 @@ pslide_vec <- function(.l,
                        .step = 1L,
                        .complete = FALSE,
                        .ptype = NULL) {
+  out <- pslide_impl(
+    .l,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .step = .step,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- pslide_vec_simplify(
-      .l,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .step = .step,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+pslide_vec_direct <- function(.l,
+                              .f,
+                              ...,
+                              .before,
+                              .after,
+                              .step,
+                              .complete,
+                              .ptype) {
   pslide_impl(
     .l,
     .f,
@@ -61,29 +70,6 @@ pslide_vec <- function(.l,
   )
 }
 
-pslide_vec_simplify <- function(.l,
-                                .f,
-                                ...,
-                                .before,
-                                .after,
-                                .step,
-                                .complete) {
-  out <- pslide_impl(
-    .l,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .step = .step,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide2
 #' @export
 pslide_dbl <- function(.l,
@@ -93,7 +79,7 @@ pslide_dbl <- function(.l,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  pslide_vec(
+  pslide_vec_direct(
     .l,
     .f,
     ...,
@@ -114,7 +100,7 @@ pslide_int <- function(.l,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  pslide_vec(
+  pslide_vec_direct(
     .l,
     .f,
     ...,
@@ -135,7 +121,7 @@ pslide_lgl <- function(.l,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  pslide_vec(
+  pslide_vec_direct(
     .l,
     .f,
     ...,
@@ -156,7 +142,7 @@ pslide_chr <- function(.l,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  pslide_vec(
+  pslide_vec_direct(
     .l,
     .f,
     ...,

--- a/R/slide-index.R
+++ b/R/slide-index.R
@@ -179,21 +179,30 @@ slide_index_vec <- function(.x,
                             .after = 0L,
                             .complete = FALSE,
                             .ptype = NULL) {
+  out <- slide_index_impl(
+    .x,
+    .i,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide_index_simplify(
-      .x,
-      .i,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide_index_vec_direct <- function(.x,
+                                   .i,
+                                   .f,
+                                   ...,
+                                   .before,
+                                   .after,
+                                   .complete,
+                                   .ptype) {
   slide_index_impl(
     .x,
     .i,
@@ -208,29 +217,6 @@ slide_index_vec <- function(.x,
   )
 }
 
-slide_index_simplify <- function(.x,
-                                 .i,
-                                 .f,
-                                 ...,
-                                 .before,
-                                 .after,
-                                 .complete) {
-  out <- slide_index_impl(
-    .x,
-    .i,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_index
 #' @export
 slide_index_dbl <- function(.x,
@@ -240,7 +226,7 @@ slide_index_dbl <- function(.x,
                             .before = 0L,
                             .after = 0L,
                             .complete = FALSE) {
-  slide_index_vec(
+  slide_index_vec_direct(
     .x,
     .i,
     .f,
@@ -261,7 +247,7 @@ slide_index_int <- function(.x,
                             .before = 0L,
                             .after = 0L,
                             .complete = FALSE) {
-  slide_index_vec(
+  slide_index_vec_direct(
     .x,
     .i,
     .f,
@@ -282,7 +268,7 @@ slide_index_lgl <- function(.x,
                             .before = 0L,
                             .after = 0L,
                             .complete = FALSE) {
-  slide_index_vec(
+  slide_index_vec_direct(
     .x,
     .i,
     .f,
@@ -303,7 +289,7 @@ slide_index_chr <- function(.x,
                             .before = 0L,
                             .after = 0L,
                             .complete = FALSE) {
-  slide_index_vec(
+  slide_index_vec_direct(
     .x,
     .i,
     .f,

--- a/R/slide-index2.R
+++ b/R/slide-index2.R
@@ -96,22 +96,32 @@ slide_index2_vec <- function(.x,
                              .after = 0L,
                              .complete = FALSE,
                              .ptype = NULL) {
+  out <- slide_index2_impl(
+    .x,
+    .y,
+    .i,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide_index2_vec_simplify(
-      .x,
-      .y,
-      .i,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide_index2_vec_direct <- function(.x,
+                                    .y,
+                                    .i,
+                                    .f,
+                                    ...,
+                                    .before,
+                                    .after,
+                                    .complete,
+                                    .ptype) {
   slide_index2_impl(
     .x,
     .y,
@@ -127,31 +137,6 @@ slide_index2_vec <- function(.x,
   )
 }
 
-slide_index2_vec_simplify <- function(.x,
-                                      .y,
-                                      .i,
-                                      .f,
-                                      ...,
-                                      .before,
-                                      .after,
-                                      .complete) {
-  out <- slide_index2_impl(
-    .x,
-    .y,
-    .i,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_index2
 #' @export
 slide_index2_dbl <- function(.x,
@@ -162,7 +147,7 @@ slide_index2_dbl <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_index2_vec(
+  slide_index2_vec_direct(
     .x,
     .y,
     .i,
@@ -185,7 +170,7 @@ slide_index2_int <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_index2_vec(
+  slide_index2_vec_direct(
     .x,
     .y,
     .i,
@@ -208,7 +193,7 @@ slide_index2_lgl <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_index2_vec(
+  slide_index2_vec_direct(
     .x,
     .y,
     .i,
@@ -231,7 +216,7 @@ slide_index2_chr <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_index2_vec(
+  slide_index2_vec_direct(
     .x,
     .y,
     .i,

--- a/R/slide-period.R
+++ b/R/slide-period.R
@@ -138,24 +138,36 @@ slide_period_vec <- function(.x,
                              .after = 0L,
                              .complete = FALSE,
                              .ptype = NULL) {
+  out <- slide_period_impl(
+    .x,
+    .i,
+    .period,
+    .f,
+    ...,
+    .every = .every,
+    .origin = .origin,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide_period_simplify(
-      .x,
-      .i,
-      .period,
-      .f,
-      ...,
-      .every = .every,
-      .origin = .origin,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide_period_vec_direct <- function(.x,
+                                    .i,
+                                    .period,
+                                    .f,
+                                    ...,
+                                    .every,
+                                    .origin,
+                                    .before,
+                                    .after,
+                                    .complete,
+                                    .ptype) {
   slide_period_impl(
     .x,
     .i,
@@ -173,35 +185,6 @@ slide_period_vec <- function(.x,
   )
 }
 
-slide_period_simplify <- function(.x,
-                                  .i,
-                                  .period,
-                                  .f,
-                                  ...,
-                                  .every,
-                                  .origin,
-                                  .before,
-                                  .after,
-                                  .complete) {
-  out <- slide_period_impl(
-    .x,
-    .i,
-    .period,
-    .f,
-    ...,
-    .every = .every,
-    .origin = .origin,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_period
 #' @export
 slide_period_dbl <- function(.x,
@@ -214,7 +197,7 @@ slide_period_dbl <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_period_vec(
+  slide_period_vec_direct(
     .x,
     .i,
     .period,
@@ -241,7 +224,7 @@ slide_period_int <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_period_vec(
+  slide_period_vec_direct(
     .x,
     .i,
     .period,
@@ -268,7 +251,7 @@ slide_period_lgl <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_period_vec(
+  slide_period_vec_direct(
     .x,
     .i,
     .period,
@@ -295,7 +278,7 @@ slide_period_chr <- function(.x,
                              .before = 0L,
                              .after = 0L,
                              .complete = FALSE) {
-  slide_period_vec(
+  slide_period_vec_direct(
     .x,
     .i,
     .period,

--- a/R/slide-period2.R
+++ b/R/slide-period2.R
@@ -112,25 +112,38 @@ slide_period2_vec <- function(.x,
                               .after = 0L,
                               .complete = FALSE,
                               .ptype = NULL) {
+  out <- slide_period2_impl(
+    .x,
+    .y,
+    .i,
+    .period,
+    .f,
+    ...,
+    .every = .every,
+    .origin = .origin,
+    .before = .before,
+    .after = .after,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide_period2_vec_simplify(
-      .x,
-      .y,
-      .i,
-      .period,
-      .f,
-      ...,
-      .every = .every,
-      .origin = .origin,
-      .before = .before,
-      .after = .after,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide_period2_vec_direct <- function(.x,
+                                     .y,
+                                     .i,
+                                     .period,
+                                     .f,
+                                     ...,
+                                     .every,
+                                     .origin,
+                                     .before,
+                                     .after,
+                                     .complete,
+                                     .ptype) {
   slide_period2_impl(
     .x,
     .y,
@@ -149,37 +162,6 @@ slide_period2_vec <- function(.x,
   )
 }
 
-slide_period2_vec_simplify <- function(.x,
-                                       .y,
-                                       .i,
-                                       .period,
-                                       .f,
-                                       ...,
-                                       .every,
-                                       .origin,
-                                       .before,
-                                       .after,
-                                       .complete) {
-  out <- slide_period2_impl(
-    .x,
-    .y,
-    .i,
-    .period,
-    .f,
-    ...,
-    .every = .every,
-    .origin = .origin,
-    .before = .before,
-    .after = .after,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide_period2
 #' @export
 slide_period2_dbl <- function(.x,
@@ -193,7 +175,7 @@ slide_period2_dbl <- function(.x,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  slide_period2_vec(
+  slide_period2_vec_direct(
     .x,
     .y,
     .i,
@@ -222,7 +204,7 @@ slide_period2_int <- function(.x,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  slide_period2_vec(
+  slide_period2_vec_direct(
     .x,
     .y,
     .i,
@@ -251,7 +233,7 @@ slide_period2_lgl <- function(.x,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  slide_period2_vec(
+  slide_period2_vec_direct(
     .x,
     .y,
     .i,
@@ -280,7 +262,7 @@ slide_period2_chr <- function(.x,
                               .before = 0L,
                               .after = 0L,
                               .complete = FALSE) {
-  slide_period2_vec(
+  slide_period2_vec_direct(
     .x,
     .y,
     .i,

--- a/R/slide.R
+++ b/R/slide.R
@@ -222,21 +222,30 @@ slide_vec <- function(.x,
                       .step = 1L,
                       .complete = FALSE,
                       .ptype = NULL) {
+  out <- slide_impl(
+    .x,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .step = .step,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide_vec_simplify(
-      .x,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .step = .step,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide_vec_direct <- function(.x,
+                             .f,
+                             ...,
+                             .before,
+                             .after,
+                             .step,
+                             .complete,
+                             .ptype) {
   slide_impl(
     .x,
     .f,
@@ -251,29 +260,6 @@ slide_vec <- function(.x,
   )
 }
 
-slide_vec_simplify <- function(.x,
-                               .f,
-                               ...,
-                               .before,
-                               .after,
-                               .step,
-                               .complete) {
-  out <- slide_impl(
-    .x,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .step = .step,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide
 #' @export
 slide_dbl <- function(.x,
@@ -283,7 +269,7 @@ slide_dbl <- function(.x,
                       .after = 0L,
                       .step = 1L,
                       .complete = FALSE) {
-  slide_vec(
+  slide_vec_direct(
     .x,
     .f,
     ...,
@@ -304,7 +290,7 @@ slide_int <- function(.x,
                       .after = 0L,
                       .step = 1L,
                       .complete = FALSE) {
-  slide_vec(
+  slide_vec_direct(
     .x,
     .f,
     ...,
@@ -325,7 +311,7 @@ slide_lgl <- function(.x,
                       .after = 0L,
                       .step = 1L,
                       .complete = FALSE) {
-  slide_vec(
+  slide_vec_direct(
     .x,
     .f,
     ...,
@@ -346,7 +332,7 @@ slide_chr <- function(.x,
                       .after = 0L,
                       .step = 1L,
                       .complete = FALSE) {
-  slide_vec(
+  slide_vec_direct(
     .x,
     .f,
     ...,

--- a/R/slide2.R
+++ b/R/slide2.R
@@ -109,22 +109,32 @@ slide2_vec <- function(.x,
                        .step = 1L,
                        .complete = FALSE,
                        .ptype = NULL) {
+  out <- slide2_impl(
+    .x,
+    .y,
+    .f,
+    ...,
+    .before = .before,
+    .after = .after,
+    .step = .step,
+    .complete = .complete,
+    .ptype = list(),
+    .constrain = FALSE,
+    .atomic = TRUE
+  )
 
-  if (is.null(.ptype)) {
-    out <- slide2_vec_simplify(
-      .x,
-      .y,
-      .f,
-      ...,
-      .before = .before,
-      .after = .after,
-      .step = .step,
-      .complete = .complete
-    )
+  vec_simplify(out, .ptype)
+}
 
-    return(out)
-  }
-
+slide2_vec_direct <- function(.x,
+                              .y,
+                              .f,
+                              ...,
+                              .before,
+                              .after,
+                              .step,
+                              .complete,
+                              .ptype) {
   slide2_impl(
     .x,
     .y,
@@ -140,31 +150,6 @@ slide2_vec <- function(.x,
   )
 }
 
-slide2_vec_simplify <- function(.x,
-                                .y,
-                                .f,
-                                ...,
-                                .before,
-                                .after,
-                                .step,
-                                .complete) {
-  out <- slide2_impl(
-    .x,
-    .y,
-    .f,
-    ...,
-    .before = .before,
-    .after = .after,
-    .step = .step,
-    .complete = .complete,
-    .ptype = list(),
-    .constrain = FALSE,
-    .atomic = TRUE
-  )
-
-  vec_simplify(out)
-}
-
 #' @rdname slide2
 #' @export
 slide2_dbl <- function(.x,
@@ -175,7 +160,7 @@ slide2_dbl <- function(.x,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  slide2_vec(
+  slide2_vec_direct(
     .x,
     .y,
     .f,
@@ -198,7 +183,7 @@ slide2_int <- function(.x,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  slide2_vec(
+  slide2_vec_direct(
     .x,
     .y,
     .f,
@@ -221,7 +206,7 @@ slide2_lgl <- function(.x,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  slide2_vec(
+  slide2_vec_direct(
     .x,
     .y,
     .f,
@@ -244,7 +229,7 @@ slide2_chr <- function(.x,
                        .after = 0L,
                        .step = 1L,
                        .complete = FALSE) {
-  slide2_vec(
+  slide2_vec_direct(
     .x,
     .y,
     .f,

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,12 +84,11 @@ compute_size <- function(x, type) {
 #
 # slide_vec(1, ~c(y = 2))
 # purrr::map_dbl(1, ~c(y = 2))
-vec_simplify <- function(x) {
+vec_simplify <- function(x, ptype) {
   names <- vec_names(x)
-
   x <- vec_set_names(x, NULL)
 
-  out <- vec_unchop(x)
+  out <- vec_unchop(x, ptype = ptype)
 
   vec_set_names(out, names)
 }

--- a/tests/testthat/helper-s3.R
+++ b/tests/testthat/helper-s3.R
@@ -1,0 +1,19 @@
+foobar <- function(x = list()) {
+  structure(x, class = "slider_foobar")
+}
+
+local_methods <- function(..., .frame = caller_env()) {
+  local_bindings(..., .env = global_env(), .frame = .frame)
+}
+
+local_c_foobar <- function(frame = caller_env()) {
+  local_methods(.frame = frame,
+    c.slider_foobar = function(...) {
+      signal("", class = "slider_c_foobar")
+      xs <- list(...)
+      xs <- lapply(xs, unclass)
+      out <- vec_unchop(xs)
+      foobar(out)
+    }
+  )
+}

--- a/tests/testthat/test-hop-index-vec.R
+++ b/tests/testthat/test-hop-index-vec.R
@@ -97,6 +97,16 @@ test_that("can return a matrix and rowwise bind the results together", {
   )
 })
 
+test_that("`hop_index_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(hop_index_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(hop_index_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(hop_index_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(hop_index_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
+})
+
 # ------------------------------------------------------------------------------
 # input names
 

--- a/tests/testthat/test-hop-index2-vec.R
+++ b/tests/testthat/test-hop-index2-vec.R
@@ -34,3 +34,13 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     "In iteration 1, the result of `.f` had size 0, not 1."
   )
 })
+
+test_that("`hop_index2_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(hop_index2_vec(1:3, 1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(hop_index2_vec(1:3, 1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(hop_index2_vec(1:3, 1:3, 1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(hop_index2_vec(1:3, 1:3, 1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
+})

--- a/tests/testthat/test-hop-vec.R
+++ b/tests/testthat/test-hop-vec.R
@@ -75,6 +75,16 @@ test_that("can return a matrix and rowwise bind the results together", {
   )
 })
 
+test_that("`hop_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(hop_vec(1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(hop_vec(1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(hop_vec(1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(hop_vec(1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
+})
+
 # ------------------------------------------------------------------------------
 # input names
 

--- a/tests/testthat/test-hop2-vec.R
+++ b/tests/testthat/test-hop2-vec.R
@@ -34,3 +34,13 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     "In iteration 1, the result of `.f` had size 0, not 1."
   )
 })
+
+test_that("`hop2_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(hop2_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(hop2_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(hop2_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(hop2_vec(1:3, 1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
+})

--- a/tests/testthat/test-phop-index-vec.R
+++ b/tests/testthat/test-phop-index-vec.R
@@ -28,9 +28,15 @@ test_that("completely empty input returns ptype", {
 })
 
 test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
+  skip("until #93 is fixed")
+
   expect_equal(
     phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = int()),
     c(NA_integer_, NA_integer_)
+  )
+  expect_equal(
+    phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = NULL),
+    c(NA, NA)
   )
 })
 
@@ -46,4 +52,14 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     phop_index_vec(list(1:2, 1:2), 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 0, not 1."
   )
+})
+
+test_that("`phop_index_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(phop_index_vec(list(1:3, 1:3), 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(phop_index_vec(list(1:3, 1:3), 1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(phop_index_vec(list(1:3, 1:3), 1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(phop_index_vec(list(1:3, 1:3), 1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })

--- a/tests/testthat/test-phop-vec.R
+++ b/tests/testthat/test-phop-vec.R
@@ -34,3 +34,13 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
     "In iteration 1, the result of `.f` had size 0, not 1."
   )
 })
+
+test_that("`phop_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(phop_vec(list(1:3, 1:3), 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(phop_vec(list(1:3, 1:3), 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(phop_vec(list(1:3, 1:3), 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(phop_vec(list(1:3, 1:3), 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
+})

--- a/tests/testthat/test-pslide-index-vec.R
+++ b/tests/testthat/test-pslide-index-vec.R
@@ -1,22 +1,28 @@
 # ------------------------------------------------------------------------------
-# pslide_index_vec
+# pslide_index_*()
 
-test_that("pslide_index_vec() works", {
+test_that("pslide_index_*() works", {
   expect_equivalent(pslide_index_vec(list(1L, 1L), 1, ~.x + .y), 2L)
+  expect_equivalent(pslide_index_int(list(1L, 1L), 1, ~.x + .y), 2L)
 })
 
-test_that("pslide_index_vec() retains names of first input", {
+test_that("pslide_index_*() retains names of first input", {
   expect_equivalent(pslide_index_vec(list(c(x = 1L), c(y = 1L)), 1, ~.x + .y), c(x = 2L))
+  expect_equivalent(pslide_index_int(list(c(x = 1L), c(y = 1L)), 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("pslide_index_vec() can simplify automatically", {
   expect_equivalent(pslide_index_vec(list(1, 2), 1, ~.x + .y, .ptype = NULL), 3)
 })
 
-test_that("pslide_index_vec() errors if it can't simplify", {
+test_that("pslide_index_*() errors if it can't simplify", {
   fn <- function(x, y) if (x == 1L) {1} else {"hi"}
   expect_error(
     pslide_index_vec(list(1:2, 1:2), 1:2, fn, .ptype = NULL),
+    class = "vctrs_error_incompatible_type"
+  )
+  expect_error(
+    pslide_index_int(list(1:2, 1:2), 1:2, fn),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -25,6 +31,7 @@ test_that("completely empty input returns ptype", {
   expect_equal(pslide_index_vec(list(), integer(), ~.x), NULL)
   expect_equal(pslide_index_vec(list(), integer(), ~.x, .ptype = list()), list())
   expect_equal(pslide_index_vec(list(), integer(), ~.x, .ptype = int()), int())
+  expect_equal(pslide_index_int(list(), integer(), ~.x), int())
 })
 
 # ------------------------------------------------------------------------------
@@ -101,4 +108,14 @@ test_that("pslide_index_dfc() works", {
 
 test_that("`.ptype = NULL` is size stable (#78)", {
   expect_length(pslide_index_vec(list(1:4, 1:4), 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})
+
+test_that("`pslide_index_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })

--- a/tests/testthat/test-pslide-period-vec.R
+++ b/tests/testthat/test-pslide-period-vec.R
@@ -6,6 +6,10 @@ test_that("size of each `.f` result must be 1", {
     pslide_period_vec(list(1:2, 1:2), new_date(1:2), "day", ~c(.x, .y)),
     "In iteration 1, the result of `.f` had size 2, not 1"
   )
+  expect_error(
+    pslide_period_int(list(1:2, 1:2), new_date(1:2), "day", ~c(.x, .y)),
+    "In iteration 1, the result of `.f` had size 2, not 1"
+  )
 })
 
 test_that("inner type is allowed to be different", {
@@ -18,6 +22,13 @@ test_that("inner type is allowed to be different", {
 test_that("inner type can be restricted with list_of", {
   expect_error(
     pslide_period_vec(list(1:2, 1:2), new_date(1:2), "day", ~if (.x == 1L) {list_of(1)} else {list_of("hi")}, .ptype = list_of(.ptype = double())),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("type can be restricted", {
+  expect_error(
+    pslide_period_int(list(1:2, 1:2), new_date(1:2), "day", ~if (.x == 1L) {1L} else {"hi"}),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -75,11 +86,23 @@ test_that("with `.complete = TRUE`, `.ptype` is used to pad", {
     ),
     c(NA, 1, 1)
   )
+})
+
+test_that("with `.complete = TRUE`, padding is size stable (#93)", {
+  skip("until #93 is fixed")
 
   expect_equal(
     pslide_period_vec(
       list(1:3, 1:3), new_date(1:3),
       "day", ~new_date(0), .before = 1, .complete = TRUE, .ptype = new_date()
+    ),
+    new_date(c(NA, 0, 0))
+  )
+
+  expect_equal(
+    pslide_period_vec(
+      list(1:3, 1:3), new_date(1:3),
+      "day", ~new_date(0), .before = 1, .complete = TRUE, .ptype = NULL
     ),
     new_date(c(NA, 0, 0))
   )
@@ -91,6 +114,16 @@ test_that("can return a matrix and rowwise bind the results together", {
     pslide_period_vec(list(1:5, 1:5), new_date(1:5), "day", ~mat, .ptype = mat),
     rbind(mat, mat, mat, mat, mat)
   )
+})
+
+test_that("`pslide_period_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(pslide_period_vec(list(1:3, 1:3), new_date(1:3), "day", ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(pslide_period_vec(list(1:3, 1:3), new_date(1:3), "day", ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(pslide_period_vec(list(1:3, 1:3), new_date(1:3), "day", ~foobar(.x)), foobar(1:3))
+  expect_condition(pslide_period_vec(list(1:3, 1:3), new_date(1:3), "day", ~foobar(.x)), class = "slider_c_foobar")
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-pslide-vec.R
+++ b/tests/testthat/test-pslide-vec.R
@@ -1,12 +1,14 @@
 # ------------------------------------------------------------------------------
-# pslide_vec
+# pslide_*()
 
-test_that("pslide_vec() works", {
+test_that("pslide_*() works", {
   expect_equivalent(pslide_vec(list(1L, 1L), ~.x + .y), 2L)
+  expect_equivalent(pslide_int(list(1L, 1L), ~.x + .y), 2L)
 })
 
-test_that("pslide_vec() retains names of first input", {
+test_that("pslide_*() retains names of first input", {
   expect_equivalent(pslide_vec(list(c(x = 1L), c(y = 1L)), ~.x + .y), c(x = 2L))
+  expect_equivalent(pslide_int(list(c(x = 1L), c(y = 1L)), ~.x + .y), c(x = 2L))
 })
 
 test_that("pslide_vec() can simplify automatically", {
@@ -17,6 +19,14 @@ test_that("pslide_vec() errors if it can't simplify", {
   fn <- function(x, y) if (x == 1L) {1} else {"hi"}
   expect_error(
     pslide_vec(list(1:2, 1:2), fn, .ptype = NULL),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("pslide_*() errors if it can't cast", {
+  fn <- function(x, y) if (x == 1L) {1} else {"hi"}
+  expect_error(
+    pslide_int(list(1:2, 1:2), fn),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -96,4 +106,14 @@ test_that("pslide_dfc() works", {
 test_that("`.ptype = NULL` is size stable (#78)", {
   expect_length(pslide_vec(list(1:4, 1:4), ~.x, .step = 2), 4)
   expect_length(pslide_vec(list(1:4, 1:4), ~1, .before = 1, .complete = TRUE), 4)
+})
+
+test_that("`pslide_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(pslide_vec(list(1:3, 1:3), ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(pslide_vec(list(1:3, 1:3), ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(pslide_vec(list(1:3, 1:3), ~foobar(.x)), foobar(1:3))
+  expect_condition(pslide_vec(list(1:3, 1:3), ~foobar(.x)), class = "slider_c_foobar")
 })

--- a/tests/testthat/test-slide-index-vec.R
+++ b/tests/testthat/test-slide-index-vec.R
@@ -6,6 +6,10 @@ test_that("size of each `.f` result must be 1", {
     slide_index_vec(1:2, 1:2, ~c(.x, 1)),
     "In iteration 1, the result of `.f` had size 2, not 1"
   )
+  expect_error(
+    slide_index_dbl(1:2, 1:2, ~c(.x, 1)),
+    "In iteration 1, the result of `.f` had size 2, not 1"
+  )
 })
 
 test_that("inner type is allowed to be different", {
@@ -18,6 +22,13 @@ test_that("inner type is allowed to be different", {
 test_that("inner type can be restricted with list_of", {
   expect_error(
     slide_index_vec(1:2, 1:2, ~if (.x == 1L) {list_of(1)} else {list_of("hi")}, .ptype = list_of(.ptype = double())),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("type of suffixed versions can be restricted", {
+  expect_error(
+    slide_index_dbl(1:2, 1:2, ~if (.x == 1L) {1} else {"hi"}),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -73,6 +84,16 @@ test_that("can return a matrix and rowwise bind the results together", {
     slide_index_vec(1:5, 1:5, ~mat, .ptype = mat),
     rbind(mat, mat, mat, mat, mat)
   )
+})
+
+test_that("`slide_index_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(slide_index_vec(1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(slide_index_vec(1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(slide_index_vec(1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(slide_index_vec(1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-slide-index2-vec.R
+++ b/tests/testthat/test-slide-index2-vec.R
@@ -1,26 +1,31 @@
 # ------------------------------------------------------------------------------
-# slide_index2_vec
+# slide_index2_*()
 
-test_that("slide_index2_vec() works", {
+test_that("slide_index2_*() works", {
   expect_equivalent(slide_index2_vec(1L, 1L, 1, ~.x + .y), 2L)
+  expect_equivalent(slide_index2_int(1L, 1L, 1, ~.x + .y), 2L)
 })
 
-test_that("slide_index2_vec() retains names of x", {
+test_that("slide_index2_*() retains names of x", {
   expect_equivalent(slide_index2_vec(c(x = 1L), c(y = 1L), 1, ~.x + .y), c(x = 2L))
+  expect_equivalent(slide_index2_int(c(x = 1L), c(y = 1L), 1, ~.x + .y), c(x = 2L))
 })
 
 test_that("slide_index2_vec() can simplify automatically", {
   expect_equivalent(slide_index2_vec(1, 2, 1, ~.x + .y, .ptype = NULL), 3)
 })
 
-test_that("slide_index2_vec() errors if it can't simplify", {
+test_that("slide_index2_*() errors if it can't simplify", {
   fn <- function(x, y) if (x == 1L) {1} else {"hi"}
   expect_error(
     slide_index2_vec(1:2, 1:2, 1:2, fn, .ptype = NULL),
     class = "vctrs_error_incompatible_type"
   )
+  expect_error(
+    slide_index2_int(1:2, 1:2, 1:2, fn),
+    class = "vctrs_error_incompatible_type"
+  )
 })
-
 
 # ------------------------------------------------------------------------------
 # suffix tests
@@ -91,4 +96,14 @@ test_that("slide_index2_dfc() works", {
 
 test_that("`.ptype = NULL` is size stable (#78)", {
   expect_length(slide_index2_vec(1:4, 1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})
+
+test_that("`slide_index2_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })

--- a/tests/testthat/test-slide-period2-vec.R
+++ b/tests/testthat/test-slide-period2-vec.R
@@ -6,6 +6,10 @@ test_that("size of each `.f` result must be 1", {
     slide_period2_vec(1:2, 1:2, new_date(1:2), "day", ~c(.x, .y)),
     "In iteration 1, the result of `.f` had size 2, not 1"
   )
+  expect_error(
+    slide_period2_int(1:2, 1:2, new_date(1:2), "day", ~c(.x, .y)),
+    "In iteration 1, the result of `.f` had size 2, not 1"
+  )
 })
 
 test_that("inner type is allowed to be different", {
@@ -18,6 +22,13 @@ test_that("inner type is allowed to be different", {
 test_that("inner type can be restricted with list_of", {
   expect_error(
     slide_period2_vec(1:2, 1:2, new_date(1:2), "day", ~if (.x == 1L) {list_of(1)} else {list_of("hi")}, .ptype = list_of(.ptype = double())),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("type can be restricted", {
+  expect_error(
+    slide_period2_int(1:2, 1:2, new_date(1:2), "day", ~if (.x == 1L) {1L} else {"hi"}),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -75,11 +86,23 @@ test_that("with `.complete = TRUE`, `.ptype` is used to pad", {
     ),
     c(NA, 1, 1)
   )
+})
+
+test_that("with `.complete = TRUE`, padding is size stable (#93)", {
+  skip("until #93 is fixed")
 
   expect_equal(
     slide_period2_vec(
       1:3, 1:3, new_date(1:3),
       "day", ~new_date(0), .before = 1, .complete = TRUE, .ptype = new_date()
+    ),
+    new_date(c(NA, 0, 0))
+  )
+
+  expect_equal(
+    slide_period2_vec(
+      1:3, 1:3, new_date(1:3),
+      "day", ~new_date(0), .before = 1, .complete = TRUE, .ptype = NULL
     ),
     new_date(c(NA, 0, 0))
   )
@@ -91,6 +114,16 @@ test_that("can return a matrix and rowwise bind the results together", {
     slide_period2_vec(1:5, 1:5, new_date(1:5), "day", ~mat, .ptype = mat),
     rbind(mat, mat, mat, mat, mat)
   )
+})
+
+test_that("`slide_period2_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(slide_period2_vec(1:3, 1:3, new_date(1:3), "day", ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(slide_period2_vec(1:3, 1:3, new_date(1:3), "day", ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(slide_period2_vec(1:3, 1:3, new_date(1:3), "day", ~foobar(.x)), foobar(1:3))
+  expect_condition(slide_period2_vec(1:3, 1:3, new_date(1:3), "day", ~foobar(.x)), class = "slider_c_foobar")
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -8,6 +8,13 @@ test_that("size of each `.f` result must be 1", {
   )
 })
 
+test_that("size of each `.f` result must be 1", {
+  expect_error(
+    slide_dbl(1:2, ~c(.x, 1)),
+    "In iteration 1, the result of `.f` had size 2, not 1"
+  )
+})
+
 test_that("inner type is allowed to be different", {
   expect_equal(
     slide_vec(1:2, ~if (.x == 1L) {list(1)} else {list("hi")}, .ptype = list()),
@@ -18,6 +25,13 @@ test_that("inner type is allowed to be different", {
 test_that("inner type can be restricted with list_of", {
   expect_error(
     slide_vec(1:2, ~if (.x == 1L) {list_of(1)} else {list_of("hi")}, .ptype = list_of(.ptype = double())),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("inner type can be restricted", {
+  expect_error(
+    slide_dbl(1:2, ~if (.x == 1L) {1} else {"x"}),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -102,13 +116,18 @@ test_that("names can be placed on atomics", {
   expect_equal(names(slide_vec(x, ~.x)), names)
   expect_equal(names(slide_vec(x, ~.x, .ptype = int())), names)
   expect_equal(names(slide_vec(x, ~.x, .ptype = dbl())), names)
+  expect_equal(names(slide_int(x, ~.x)), names)
+  expect_equal(names(slide_dbl(x, ~.x)), names)
 })
 
-test_that("when simplifying, names from `.x` are kept, and new names from `.f` results are dropped", {
+test_that("names from `.x` are kept, and new names from `.f` results are dropped", {
   x <- set_names(1, "x")
 
   expect_identical(slide_vec(x, ~c(y = 2), .ptype = NULL), c(x = 2))
   expect_identical(slide_vec(1, ~c(y = 2), .ptype = NULL), 2)
+
+  expect_identical(slide_dbl(x, ~c(y = 2)), c(x = 2))
+  expect_identical(slide_dbl(1, ~c(y = 2)), 2)
 })
 
 test_that("names can be placed on data frames", {

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -76,6 +76,16 @@ test_that("can return a matrix and rowwise bind the results together", {
   )
 })
 
+test_that("`slide_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(slide_vec(1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(slide_vec(1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(slide_vec(1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(slide_vec(1:3, ~foobar(.x)), class = "slider_c_foobar")
+})
+
 # ------------------------------------------------------------------------------
 # input names
 

--- a/tests/testthat/test-slide2-vec.R
+++ b/tests/testthat/test-slide2-vec.R
@@ -1,12 +1,14 @@
 # ------------------------------------------------------------------------------
-# slide2_vec
+# slide2_*()
 
-test_that("slide2_vec() works", {
+test_that("slide2_*() works", {
   expect_equivalent(slide2_vec(1L, 1L, ~.x + .y), 2L)
+  expect_equivalent(slide2_int(1L, 1L, ~.x + .y), 2L)
 })
 
-test_that("slide2_vec() retains names of x", {
+test_that("slide2_*() retains names of x", {
   expect_equivalent(slide2_vec(c(x = 1L), c(y = 1L), ~.x + .y), c(x = 2L))
+  expect_equivalent(slide2_int(c(x = 1L), c(y = 1L), ~.x + .y), c(x = 2L))
 })
 
 test_that("slide2_vec() can simplify automatically", {
@@ -17,6 +19,14 @@ test_that("slide2_vec() errors if it can't simplify", {
   fn <- function(x, y) if (x == 1L) {1} else {"hi"}
   expect_error(
     slide2_vec(1:2, 1:2, fn, .ptype = NULL),
+    class = "vctrs_error_incompatible_type"
+  )
+})
+
+test_that("slide2_*() errors if it can't cast", {
+  fn <- function(x, y) if (x == 1L) {1} else {"hi"}
+  expect_error(
+    slide2_int(1:2, 1:2, fn),
     class = "vctrs_error_incompatible_type"
   )
 })
@@ -97,4 +107,14 @@ test_that("slide2_dfc() works", {
 test_that("`.ptype = NULL` is size stable (#78)", {
   expect_length(slide2_vec(1:4, 1:4, ~.x, .step = 2), 4)
   expect_length(slide2_vec(1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
+})
+
+test_that("`slide2_vec()` falls back to `c()` method as required", {
+  local_c_foobar()
+
+  expect_identical(slide2_vec(1:3, 1:3, ~foobar(.x), .ptype = foobar()), foobar(1:3))
+  expect_condition(slide2_vec(1:3, 1:3, ~foobar(.x), .ptype = foobar()), class = "slider_c_foobar")
+
+  expect_identical(slide2_vec(1:3, 1:3, ~foobar(.x)), foobar(1:3))
+  expect_condition(slide2_vec(1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })


### PR DESCRIPTION
For restricted suffix variants like `slide_dbl()`, there is no problem at all to init an output container, proxy it, assign into it, and restore it, all at the C level in slider. This is essentially an optimized `vec_c()` call.

However, `slide_vec()` can return _any_ type of vector through its `.ptype` parameter. To combine the results of each call to `.f` robustly, we need to go through `vec_unchop()`, which goes through `vec_c()`, rather than doing the proxy-assign-restore approach that happens in the simple cases.

We have to do this because `vec_c()` is coded specially to "fallback" to `base::c()` in cases where the inputs are all homogeneous, don't have a vec-proxy method, and implement a `c()` method. We wouldn't get this behavior in our custom proxy-assign-restore code.

Using `vec_unchop()` is slightly slower, because we have to first assign into a list, then unchop that list, rather than assigning directly into the final container. This results in an extra list allocation with size equal to the size of `x`. But it is worth it to be more robust here. The performance penalty only applies to `slide_vec()`, not `slide_dbl()`, so I'm not too worried about it.

```r
library(slider)

exprs <- rlang::exprs(
  fast = slide_dbl(x, identity),
  slow = slide_vec(x, identity, .ptype = double())
)

bench::press(
  size = c(500, 5000, 10000, 25000, 50000),
  {
    x <- seq_len(size) + 0
    bench::mark(exprs = exprs, iterations = 200)
  }
)
#> Running with:
#>    size
#> 1   500
#> 2  5000
#> 3 10000
#> 4 25000
#> 5 50000
#> # A tibble: 10 x 7
#>    expression  size      min   median `itr/sec` mem_alloc `gc/sec`
#>    <bch:expr> <dbl> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#>  1 fast         500 242.43µs 301.23µs    3309.    107.2KB     16.6
#>  2 slow         500 300.17µs 318.31µs    3118.     51.7KB     31.5
#>  3 fast        5000   2.24ms   2.74ms     367.     39.1KB     21.4
#>  4 slow        5000   2.22ms   2.73ms     374.     97.8KB     23.9
#>  5 fast       10000   4.39ms   5.22ms     192.     78.2KB     25.0
#>  6 slow       10000    4.4ms   5.63ms     179.    195.5KB     26.7
#>  7 fast       25000  10.17ms  13.65ms      75.8   195.4KB     30.2
#>  8 slow       25000  11.45ms  16.45ms      59.9   488.4KB     35.9
#>  9 fast       50000  19.95ms   24.1ms      40.2   390.7KB     57.9
#> 10 slow       50000  24.81ms  37.26ms      26.5   976.7KB    112.

exprs <- rlang::exprs(
  fast = slide_dbl(x, mean, .before = 5),
  slow = slide_vec(x, mean, .before = 5, .ptype = double())
)

bench::press(
  size = c(500, 5000, 10000, 25000),
  {
    x <- seq_len(size) + 0
    bench::mark(exprs = exprs, iterations = 200)
  }
)
#> Running with:
#>    size
#> 1   500
#> 2  5000
#> 3 10000
#> 4 25000
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 8 x 7
#>   expression  size      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <dbl> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 fast         500   1.79ms   1.93ms     516.     3.95KB     30.0
#> 2 slow         500    1.6ms   1.87ms     536.     9.91KB     19.5
#> 3 fast        5000   11.3ms  16.97ms      60.1   39.11KB     33.1
#> 4 slow        5000  14.09ms  17.37ms      59.4    97.8KB     33.4
#> 5 fast       10000   23.2ms  28.95ms      34.0   78.17KB     69.0
#> 6 slow       10000  27.05ms  34.83ms      28.0  195.45KB    109. 
#> 7 fast       25000  58.49ms  65.63ms      14.6  195.36KB     24.5
#> 8 slow       25000  64.99ms 101.69ms      10.1  488.42KB     22.2
```