### PR TITLE
Fix `slide_period()` size stability

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # slider (development version)
 
+* A few edge cases with size zero input in the index functions have been fixed.
+
 * The default for the `.names_to` argument of `*_dfr()` variants has been
   updated to `rlang::zap()` to match the default of the function it is passed
   on to, `vctrs::vec_rbind()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
   on to, `vctrs::vec_rbind()`.
 
 * All `*_vec()` variants now maintain size stability when auto-simplifying
-  (i.e. when `.ptype = NULL`) (#78).
+  (i.e. when `.ptype = NULL`) (#78, #93).
 
 * `hop()` and its variants no longer place the names of `.x` on the output.
   Because there is no _size_ guarantee on the output, the size of `.x` can

--- a/R/hop-index-common.R
+++ b/R/hop-index-common.R
@@ -31,16 +31,6 @@ hop_index_common <- function(x,
   args <- vec_cast_common(i, !!!args)
   args <- lapply(args, vec_proxy_compare)
 
-  # Early exit if empty input
-  # (but after all size checks have been done)
-  if (size == 0L) {
-    return(vec_init(ptype, 0L))
-  }
-
-  if (x_size == 0L) {
-    return(vec_init(ptype, size))
-  }
-
   i <- args[[1L]]
   starts <- args[[2L]]
   stops <- args[[3L]]

--- a/R/slide-index-common.R
+++ b/R/slide-index-common.R
@@ -21,12 +21,6 @@ slide_index_common <- function(x,
   check_index_cannot_be_na(i, ".i")
   check_index_must_be_ascending(i, ".i")
 
-  # Early exit if empty input
-  # (but after the index size check)
-  if (x_size == 0L) {
-    return(vec_init(ptype, 0L))
-  }
-
   check_before(before)
   check_after(after)
   complete <- check_complete(complete)

--- a/R/slide-period-common.R
+++ b/R/slide-period-common.R
@@ -68,11 +68,14 @@ slide_period_common <- function(x,
     return(out)
   }
 
-  # Pad with ptype
-  init <- vec_init(ptype, n = 1L)
-
-  front <- vec_recycle(init, from - 1L)
-  back <- vec_recycle(init, n - to)
+  # Initialize with `NA`, not `NULL`, for size stability when auto-simplifying
+  if (atomic && !constrain) {
+    front <- vec_init_unspecified_list(n = from - 1L)
+    back <- vec_init_unspecified_list(n = n - to)
+  } else {
+    front <- vec_init(ptype, n = from - 1L)
+    back <- vec_init(ptype, n = n - to)
+  }
 
   out <- vec_c(front, out, back)
 
@@ -129,4 +132,8 @@ check_slide_period_complete <- function(x) {
   }
 
   x
+}
+
+vec_init_unspecified_list <- function(n) {
+  rep_len(list(NA), n)
 }

--- a/src/index.c
+++ b/src/index.c
@@ -370,19 +370,12 @@ static void compute_window_sizes(int* window_sizes,
 static void compute_window_starts(int* window_starts,
                                   int* window_sizes,
                                   int size) {
-  if (size == 0) {
-    return;
-  }
-
-  // First start is always 0
-  window_starts[0] = 0;
-
   int sum = 0;
 
-  // Then we do a cumsum() to get the rest of the starts
-  for (int i = 1; i < size; ++i) {
-    sum += window_sizes[i - 1];
+  // First start is always 0, then a cumsum() to get the rest of the starts
+  for (int i = 0; i < size; ++i) {
     window_starts[i] = sum;
+    sum += window_sizes[i];
   }
 }
 

--- a/src/index.c
+++ b/src/index.c
@@ -370,6 +370,10 @@ static void compute_window_sizes(int* window_sizes,
 static void compute_window_starts(int* window_starts,
                                   int* window_sizes,
                                   int size) {
+  if (size == 0) {
+    return;
+  }
+
   // First start is always 0
   window_starts[0] = 0;
 

--- a/tests/testthat/test-hop-index-vec.R
+++ b/tests/testthat/test-hop-index-vec.R
@@ -56,10 +56,14 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
   )
 })
 
-test_that("`.ptype = NULL` returns `NULL` with size 0 `.starts` / `.stops`", {
-  expect_equal(
-    hop_index_vec(integer(), integer(), integer(), integer(), ~.x, .ptype = NULL),
+test_that("size 0 `.starts` / `.stops` returns size 0 `.ptype`", {
+  expect_identical(
+    hop_index_vec(1:5, 1:5, integer(), integer(), ~.x, .ptype = NULL),
     NULL
+  )
+  expect_identical(
+    hop_index_vec(1:5, 1:5, integer(), integer(), ~.x, .ptype = double()),
+    double()
   )
 })
 

--- a/tests/testthat/test-hop-index.R
+++ b/tests/testthat/test-hop-index.R
@@ -41,8 +41,8 @@ test_that("empty input returns a list, but after the index size check", {
   expect_error(hop_index(integer(), 1, integer(), integer(), ~.x), class = "slider_error_index_incompatible_size")
 })
 
-test_that("empty `.x` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
-  expect_equal(hop_index(integer(), integer(), 1:2, 2:3, ~.x), list(NULL, NULL))
+test_that("empty `.x` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` ptype", {
+  expect_equal(hop_index(integer(), integer(), 1:2, 2:3, ~.x), list(integer(), integer()))
 })
 
 test_that("empty `.x` and `.i`, but size `n > 0` `.starts` and `.stops`: sizes and types are checked first", {

--- a/tests/testthat/test-hop-index2-vec.R
+++ b/tests/testthat/test-hop-index2-vec.R
@@ -35,6 +35,17 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
   )
 })
 
+test_that("size 0 `.starts` / `.stops` returns size 0 `.ptype`", {
+  expect_identical(
+    hop_index2_vec(1:5, 1:5, 1:5, integer(), integer(), ~.x, .ptype = NULL),
+    NULL
+  )
+  expect_identical(
+    hop_index2_vec(1:5, 1:5, 1:5, integer(), integer(), ~.x, .ptype = double()),
+    double()
+  )
+})
+
 test_that("`hop_index2_vec()` falls back to `c()` method as required", {
   local_c_foobar()
 

--- a/tests/testthat/test-hop-index2.R
+++ b/tests/testthat/test-hop-index2.R
@@ -49,7 +49,7 @@ test_that("empty input returns a list, but after the index size check", {
 })
 
 test_that("empty `.x` and `.y` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
-  expect_equal(hop_index2(integer(), integer(), integer(), 1:2, 2:3, ~.x), list(NULL, NULL))
+  expect_equal(hop_index2(integer(), integer(), integer(), 1:2, 2:3, ~.x), list(integer(), integer()))
 })
 
 test_that("empty `.x` and `.y` and `.i`, but size `n > 0` `.starts` and `.stops`: sizes and types are checked first", {

--- a/tests/testthat/test-phop-index-vec.R
+++ b/tests/testthat/test-phop-index-vec.R
@@ -39,10 +39,8 @@ test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns 
 })
 
 test_that("can't access non-existant `.x` with empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`", {
-  expect_error(
-    phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = int()),
-    "list contains fewer than 1 element"
-  )
+  # Note: Error message seems platform dependent
+  expect_error(phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = int()))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-phop-index-vec.R
+++ b/tests/testthat/test-phop-index-vec.R
@@ -27,16 +27,21 @@ test_that("completely empty input returns ptype", {
   expect_equal(phop_index_vec(list(), integer(), integer(), integer(), ~.x, .ptype = int()), int())
 })
 
-test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
-  skip("until #93 is fixed")
-
-  expect_equal(
-    phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = int()),
-    c(NA_integer_, NA_integer_)
+test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` ptype", {
+  expect_identical(
+    phop_index_vec(list(), integer(), 1:2, 2:3, ~2, .ptype = int()),
+    c(2L, 2L)
   )
-  expect_equal(
-    phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = NULL),
-    c(NA, NA)
+  expect_identical(
+    phop_index_vec(list(), integer(), 1:2, 2:3, ~2, .ptype = NULL),
+    c(2, 2)
+  )
+})
+
+test_that("can't access non-existant `.x` with empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`", {
+  expect_error(
+    phop_index_vec(list(), integer(), 1:2, 2:3, ~.x, .ptype = int()),
+    "list contains fewer than 1 element"
   )
 })
 
@@ -51,6 +56,17 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
   expect_error(
     phop_index_vec(list(1:2, 1:2), 1:2, 1:2, 1:2, ~if(.x == 1L) {NULL} else {2}, .ptype = NULL),
     "In iteration 1, the result of `.f` had size 0, not 1."
+  )
+})
+
+test_that("size 0 `.starts` / `.stops` returns size 0 `.ptype`", {
+  expect_identical(
+    phop_index_vec(list(1:5), 1:5, integer(), integer(), ~.x, .ptype = NULL),
+    NULL
+  )
+  expect_identical(
+    phop_index_vec(list(1:5), 1:5, integer(), integer(), ~.x, .ptype = double()),
+    double()
   )
 })
 

--- a/tests/testthat/test-phop-index.R
+++ b/tests/testthat/test-phop-index.R
@@ -15,10 +15,8 @@ test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns 
 })
 
 test_that("can't access non-existant `.x` with empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`", {
-  expect_error(
-    phop_index(list(), integer(), 1:2, 2:3, ~.x),
-    "list contains fewer than 1 element"
-  )
+  # Note: Error message seems platform dependent
+  expect_error(phop_index(list(), integer(), 1:2, 2:3, ~.x))
 })
 
 test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`: sizes and types are checked first", {

--- a/tests/testthat/test-phop-index.R
+++ b/tests/testthat/test-phop-index.R
@@ -10,8 +10,15 @@ test_that("completely empty input returns a list", {
   expect_equal(phop_index(list(), integer(), integer(), integer(), ~.x), list())
 })
 
-test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
-  expect_equal(phop_index(list(), integer(), 1:2, 2:3, ~.x), list(NULL, NULL))
+test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops` returns size `n` ptype", {
+  expect_equal(phop_index(list(), integer(), 1:2, 2:3, ~2), list(2, 2))
+})
+
+test_that("can't access non-existant `.x` with empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`", {
+  expect_error(
+    phop_index(list(), integer(), 1:2, 2:3, ~.x),
+    "list contains fewer than 1 element"
+  )
 })
 
 test_that("empty `.l` and `.i`, but size `n > 0` `.starts` and `.stops`: sizes and types are checked first", {

--- a/tests/testthat/test-pslide-period-vec.R
+++ b/tests/testthat/test-pslide-period-vec.R
@@ -89,8 +89,6 @@ test_that("with `.complete = TRUE`, `.ptype` is used to pad", {
 })
 
 test_that("with `.complete = TRUE`, padding is size stable (#93)", {
-  skip("until #93 is fixed")
-
   expect_equal(
     pslide_period_vec(
       list(1:3, 1:3), new_date(1:3),
@@ -98,7 +96,13 @@ test_that("with `.complete = TRUE`, padding is size stable (#93)", {
     ),
     new_date(c(NA, 0, 0))
   )
-
+  expect_equal(
+    pslide_period_vec(
+      list(1:3, 1:3), new_date(1:3),
+      "day", ~new_date(0), .after = 1, .complete = TRUE, .ptype = new_date()
+    ),
+    new_date(c(0, 0, NA))
+  )
   expect_equal(
     pslide_period_vec(
       list(1:3, 1:3), new_date(1:3),

--- a/tests/testthat/test-slide-index-vec.R
+++ b/tests/testthat/test-slide-index-vec.R
@@ -63,8 +63,9 @@ test_that("`.ptype = NULL` validates that element lengths are 1", {
   )
 })
 
-test_that("`.ptype = NULL` returns `NULL` with size 0 `.x`", {
-  expect_equal(slide_index_vec(integer(), integer(), ~.x, .ptype = NULL), NULL)
+test_that("size 0 `.x` returns .ptype", {
+  expect_identical(slide_index_vec(integer(), integer(), ~.x, .ptype = NULL), NULL)
+  expect_identical(slide_index_vec(integer(), integer(), ~.x, .ptype = double()), double())
 })
 
 test_that("`.ptype = NULL` is size stable (#78)", {

--- a/tests/testthat/test-slide-index2-vec.R
+++ b/tests/testthat/test-slide-index2-vec.R
@@ -98,6 +98,11 @@ test_that("`.ptype = NULL` is size stable (#78)", {
   expect_length(slide_index2_vec(1:4, 1:4, 1:4, ~1, .before = 1, .complete = TRUE), 4)
 })
 
+test_that("size 0 inputs returns .ptype", {
+  expect_identical(slide_index2_vec(integer(), integer(), integer(), ~.x, .ptype = NULL), NULL)
+  expect_identical(slide_index2_vec(integer(), integer(), integer(), ~.x, .ptype = double()), double())
+})
+
 test_that("`slide_index2_vec()` falls back to `c()` method as required", {
   local_c_foobar()
 

--- a/tests/testthat/test-slide-period-vec.R
+++ b/tests/testthat/test-slide-period-vec.R
@@ -89,8 +89,6 @@ test_that("with `.complete = TRUE`, `.ptype` is used to pad", {
 })
 
 test_that("with `.complete = TRUE`, padding is size stable (#93)", {
-  skip("until #93 is fixed")
-
   expect_equal(
     slide_period_vec(
       1:3, new_date(1:3),
@@ -98,7 +96,13 @@ test_that("with `.complete = TRUE`, padding is size stable (#93)", {
     ),
     new_date(c(NA, 0, 0))
   )
-
+  expect_equal(
+    slide_period_vec(
+      1:3, new_date(1:3),
+      "day", ~new_date(0), .after = 1, .complete = TRUE, .ptype = new_date()
+    ),
+    new_date(c(0, 0, NA))
+  )
   expect_equal(
     slide_period_vec(
       1:3, new_date(1:3),

--- a/tests/testthat/test-slide-period2-vec.R
+++ b/tests/testthat/test-slide-period2-vec.R
@@ -89,8 +89,6 @@ test_that("with `.complete = TRUE`, `.ptype` is used to pad", {
 })
 
 test_that("with `.complete = TRUE`, padding is size stable (#93)", {
-  skip("until #93 is fixed")
-
   expect_equal(
     slide_period2_vec(
       1:3, 1:3, new_date(1:3),
@@ -98,7 +96,13 @@ test_that("with `.complete = TRUE`, padding is size stable (#93)", {
     ),
     new_date(c(NA, 0, 0))
   )
-
+  expect_equal(
+    slide_period2_vec(
+      1:3, 1:3, new_date(1:3),
+      "day", ~new_date(0), .after = 1, .complete = TRUE, .ptype = new_date()
+    ),
+    new_date(c(0, 0, NA))
+  )
   expect_equal(
     slide_period2_vec(
       1:3, 1:3, new_date(1:3),


### PR DESCRIPTION
Closes #93 

Also removes the special case early exists in `slide_index_common()` and `hop_index_common()`. There was an underlying bug in `compute_window_starts()` that was causing R to crash. Fixing this removed the need for any special case code.