### PR TITLE
Revise window computation with hop in mind

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -379,46 +379,54 @@ static void fill_window_info(int* window_sizes,
 // update the current start/stop position
 
 static int locate_window_starts_pos(struct index_info* index, struct range_info range, int pos) {
-  if (range.start_unbounded || index->compare_lt(range.starts, pos, index->data, 0)) {
-    if (range.stop_unbounded) {
-      return 0;
-    }
-
-    if (index->compare_lt(range.stops, pos, index->data, 0)) {
-      return -1;
-    }
-
+  if (range.start_unbounded) {
     return 0;
   }
 
-  while(index->compare_lt(index->data, index->current_start_pos, range.starts, pos)) {
-    if (index->current_start_pos == index->last_pos) {
-      return index->current_start_pos;
-    }
+  // We are already past the end, return `last_pos + 1`
+  if (index->current_start_pos > index->last_pos) {
+    return index->last_pos + 1;
+  }
+
+  // Start is before the first index value. Pin to `0`.
+  if (index->compare_lt(range.starts, pos, index->data, 0)) {
+    return 0;
+  }
+
+  while (index->compare_lt(index->data, index->current_start_pos, range.starts, pos)) {
     ++index->current_start_pos;
+
+    // Are we out of values?
+    if (index->current_start_pos > index->last_pos) {
+      return index->last_pos + 1;
+    }
   }
 
   return index->current_start_pos;
 }
 
 static int locate_window_stops_pos(struct index_info* index, struct range_info range, int pos) {
-  if (range.stop_unbounded || index->compare_gt(range.stops, pos, index->data, index->last_pos)) {
-    if (range.start_unbounded) {
-      return index->last_pos;
-    }
-
-    if (index->compare_gt(range.starts, pos, index->data, index->last_pos)) {
-      return -1;
-    }
-
+  if (range.stop_unbounded) {
     return index->last_pos;
   }
 
-  while(index->compare_lte(index->data, index->current_stop_pos, range.stops, pos)) {
-    if (index->current_stop_pos == index->last_pos) {
-      return index->current_stop_pos;
-    }
+  // We are already past the end, return `last_pos`
+  if (index->current_stop_pos > index->last_pos) {
+    return index->last_pos;
+  }
+
+  // Stop is before first index value. Pin to `0 - 1`.
+  if (index->compare_lt(range.stops, pos, index->data, 0)) {
+    return -1;
+  }
+
+  while (index->compare_lte(index->data, index->current_stop_pos, range.stops, pos)) {
     ++index->current_stop_pos;
+
+    // Are we out of values?
+    if (index->current_stop_pos > index->last_pos) {
+      return index->last_pos;
+    }
   }
 
   return index->current_stop_pos - 1;
@@ -433,16 +441,6 @@ static void increment_window(struct window_info window,
   int starts_pos = locate_window_starts_pos(index, range, pos);
   int stops_pos = locate_window_stops_pos(index, range, pos);
 
-  // This is our signal that we are outside the range of `i`. For example,
-  // i = 1:2, but we are trying to index [start = 3, stop = 4]. In these cases
-  // there is "no data" in that range, so we pass a size 0 slice of `x` to `f`
-  if (starts_pos == -1 || stops_pos == -1) {
-    init_compact_seq(window.p_seq_val, 0, 0, true);
-    return;
-  }
-
-  // This can happen with an irregular index, and is a sign of the full window
-  // being between two index points and means we select nothing
   if (stops_pos < starts_pos) {
     init_compact_seq(window.p_seq_val, 0, 0, true);
     return;


### PR DESCRIPTION
On Windows 32 bit, I was seeing a number of segfault failures after removing the special early exits for size 0 `x` in https://github.com/DavisVaughan/slider/commits/master

It turns out that for `hop_index()`, I was not guarding against empty `index` values properly, and was actually trying to do `index[0]` when computing the window start/stops. This is undefined behavior and I'm surprised it only failed on 32 bit windows.

An example of the problematic behavior is:

```r
hop_index(integer(), integer(), 1:2, 2:3, ~.x)
```

This revision rewrites the functions that locate the window starts/stops and seems to simplify them a lot.

We now rely heavily on the behavior of having `stops_pos < starts_pos` mean that we should do a 0-element slice of `x`. I think this is reasonable, and it captures the following edge cases:

- Having a window completely outside the range of `.i`. i.e.:
   - `i = [1, 2], starts = 3, stops = 4` 
   - `i = [3, 4], starts = 1, stops = 2`

- Having a window in a "gap" in an irregular `.i`

   - `i = c(1, 4), starts = 2, stops = 3`

- Having an empty `.i`, but `.starts` / `.stops` with size

   - `i = integer(), starts = 1, stops = 2`

The last case works because of the following default values:
   - `current_start_pos = 0`
   - `current_stop_pos = 0`
   - `last_pos = size - 1 = -1`

We return:
   - `starts_pos = last_pos + 1 = 0` when  `current_start_pos > last_pos`
   - `stops_pos = last_pos = -1` when `current_stop_pos > last_pos`

So it falls out that `stops_pos < starts_pos` and the 0-slice case correctly kicks in  