### PR TITLE
Be less reliant on vctrs internals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # slider (development version)
 
+* C code has been refactored to be less reliant on vctrs internals.
+
 # slider 0.1.3
 
 * Updated to stay compatible with vctrs 0.3.0.

--- a/src/assign.h
+++ b/src/assign.h
@@ -1,0 +1,35 @@
+#ifndef SLIDER_ASSIGN_H
+#define SLIDER_ASSIGN_H
+
+#include "slider.h"
+#include "slider-vctrs.h"
+
+// -----------------------------------------------------------------------------
+
+static inline void assign_one_dbl(double* p_out, R_len_t i, SEXP elt, SEXP ptype) {
+  elt = vec_cast(elt, ptype);
+  p_out[i] = REAL_RO(elt)[0];
+}
+
+static inline void assign_one_int(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
+  elt = vec_cast(elt, ptype);
+  p_out[i] = INTEGER_RO(elt)[0];
+}
+
+static inline void assign_one_lgl(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
+  elt = vec_cast(elt, ptype);
+  p_out[i] = LOGICAL_RO(elt)[0];
+}
+
+static inline void assign_one_chr(SEXP* p_out, R_len_t i, SEXP elt, SEXP ptype) {
+  elt = vec_cast(elt, ptype);
+  p_out[i] = STRING_PTR_RO(elt)[0];
+}
+
+static inline void assign_one_lst(SEXP out, R_len_t i, SEXP elt, SEXP ptype) {
+  SET_VECTOR_ELT(out, i, elt);
+}
+
+// -----------------------------------------------------------------------------
+
+#endif

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,4 +32,47 @@ static inline void assign_one_lst(SEXP out, R_len_t i, SEXP elt, SEXP ptype) {
 
 // -----------------------------------------------------------------------------
 
+#define ASSIGN_LOCS(CTYPE, CONST_DEREF) do {                   \
+  const R_len_t size = Rf_length(locations);                   \
+  const int* p_locations = INTEGER_RO(locations);              \
+                                                               \
+  elt = PROTECT(vec_cast(elt, ptype));                         \
+  const CTYPE value = CONST_DEREF(elt)[0];                     \
+                                                               \
+  for (R_len_t i = 0; i < size; ++i) {                         \
+    /* `locations` are 1-based */                              \
+    R_len_t loc = p_locations[i] - 1;                          \
+    p_out[loc] = value;                                        \
+  }                                                            \
+                                                               \
+  UNPROTECT(1);                                                \
+} while (0)
+
+static inline void assign_locs_dbl(double* p_out, SEXP locations, SEXP elt, SEXP ptype) {
+  ASSIGN_LOCS(double, REAL_RO);
+}
+static inline void assign_locs_int(int* p_out, SEXP locations, SEXP elt, SEXP ptype) {
+  ASSIGN_LOCS(int, INTEGER_RO);
+}
+static inline void assign_locs_lgl(int* p_out, SEXP locations, SEXP elt, SEXP ptype) {
+  ASSIGN_LOCS(int, LOGICAL_RO);
+}
+static inline void assign_locs_chr(SEXP* p_out, SEXP locations, SEXP elt, SEXP ptype) {
+  ASSIGN_LOCS(SEXP, STRING_PTR_RO);
+}
+
+#undef ASSIGN_LOCS
+
+static inline void assign_locs_lst(SEXP out, SEXP locations, SEXP elt, SEXP ptype) {
+  const R_len_t size = Rf_length(locations);
+  const int* p_locations = INTEGER_RO(locations);
+
+  for (R_len_t i = 0; i < size; ++i) {
+    R_len_t loc = p_locations[i] - 1;
+    SET_VECTOR_ELT(out, loc, elt);
+  }
+}
+
+// -----------------------------------------------------------------------------
+
 #endif

--- a/src/assign.h
+++ b/src/assign.h
@@ -6,25 +6,25 @@
 
 // -----------------------------------------------------------------------------
 
+#define ASSIGN_ONE(CONST_DEREF) do {  \
+  elt = vec_cast(elt, ptype);         \
+  p_out[i] = CONST_DEREF(elt)[0];     \
+} while (0)
+
 static inline void assign_one_dbl(double* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = REAL_RO(elt)[0];
+  ASSIGN_ONE(REAL_RO);
 }
-
 static inline void assign_one_int(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = INTEGER_RO(elt)[0];
+  ASSIGN_ONE(INTEGER_RO);
 }
-
 static inline void assign_one_lgl(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = LOGICAL_RO(elt)[0];
+  ASSIGN_ONE(LOGICAL_RO);
+}
+static inline void assign_one_chr(SEXP* p_out, R_len_t i, SEXP elt, SEXP ptype) {
+  ASSIGN_ONE(STRING_PTR_RO);
 }
 
-static inline void assign_one_chr(SEXP* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = STRING_PTR_RO(elt)[0];
-}
+#undef ASSIGN_ONE
 
 static inline void assign_one_lst(SEXP out, R_len_t i, SEXP elt, SEXP ptype) {
   SET_VECTOR_ELT(out, i, elt);

--- a/src/hop.c
+++ b/src/hop.c
@@ -103,6 +103,7 @@ SEXP hop_common_impl(SEXP x,
   case LGLSXP:  HOP_LOOP_ATOMIC(int, LOGICAL, assign_one_lgl); break;
   case STRSXP:  HOP_LOOP_ATOMIC(SEXP, STRING_PTR, assign_one_chr); break;
   case VECSXP:  HOP_LOOP_BARRIER(assign_one_lst); break;
+  default:      never_reached("hop_common_impl");
   }
 
   UNPROTECT(4);

--- a/src/index.c
+++ b/src/index.c
@@ -124,6 +124,7 @@ SEXP slide_index_common_impl(SEXP x,
   case LGLSXP:  SLIDE_INDEX_LOOP_ATOMIC(int, LOGICAL, assign_locs_lgl); break;
   case STRSXP:  SLIDE_INDEX_LOOP_ATOMIC(SEXP, STRING_PTR, assign_locs_chr); break;
   case VECSXP:  SLIDE_INDEX_LOOP_BARRIER(assign_locs_lst); break;
+  default:      never_reached("slide_index_common_impl");
   }
 
   SEXP names = slider_names(x, type);
@@ -228,6 +229,7 @@ SEXP hop_index_common_impl(SEXP x,
   case LGLSXP:  HOP_INDEX_LOOP_ATOMIC(int, LOGICAL, assign_one_lgl); break;
   case STRSXP:  HOP_INDEX_LOOP_ATOMIC(SEXP, STRING_PTR, assign_one_chr); break;
   case VECSXP:  HOP_INDEX_LOOP_BARRIER(assign_one_lst); break;
+  default:      never_reached("hop_index_common_impl");
   }
 
   UNPROTECT(n_prot);

--- a/src/slide.c
+++ b/src/slide.c
@@ -72,11 +72,6 @@ SEXP slide_common_impl(SEXP x,
   const int force = compute_force(type);
   const int size = compute_size(x, type);
 
-  // Bail early if inputs are size 0
-  if (size == 0) {
-    return Rf_allocVector(TYPEOF(ptype), 0);
-  }
-
   bool before_unbounded = false;
   bool after_unbounded = false;
 

--- a/src/slide.c
+++ b/src/slide.c
@@ -74,7 +74,7 @@ SEXP slide_common_impl(SEXP x,
 
   // Bail early if inputs are size 0
   if (size == 0) {
-    return vec_init(ptype, 0);
+    return Rf_allocVector(TYPEOF(ptype), 0);
   }
 
   const int force = compute_force(type);

--- a/src/slide.c
+++ b/src/slide.c
@@ -2,78 +2,61 @@
 #include "slider-vctrs.h"
 #include "utils.h"
 #include "params.h"
+#include "assign.h"
 
 // -----------------------------------------------------------------------------
 
-static inline void assign_one_dbl(double* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = REAL_RO(elt)[0];
-}
-static inline void assign_one_int(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = INTEGER_RO(elt)[0];
-}
-static inline void assign_one_lgl(int* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = LOGICAL_RO(elt)[0];
-}
-static inline void assign_one_chr(SEXP* p_out, R_len_t i, SEXP elt, SEXP ptype) {
-  elt = vec_cast(elt, ptype);
-  p_out[i] = STRING_PTR_RO(elt)[0];
-}
-static inline void assign_one_lst(SEXP out, R_len_t i, SEXP elt, SEXP ptype) {
-  SET_VECTOR_ELT(out, i, elt);
-}
-
-#define SLIDE_LOOP(ASSIGN_ONE_FN) do {   \
-  for (int i = iteration_min;                                  \
-       i < iteration_max;                                      \
-       i += step, start += start_step, stop += stop_step) {    \
-    if (i % 1024 == 0) {                                       \
-      R_CheckUserInterrupt();                                  \
-    }                                                          \
-                                                               \
-    int window_start = max(start, 0);                          \
-    int window_stop = min(stop, size - 1);                     \
-    int window_size = window_stop - window_start + 1;          \
-                                                               \
-    /* Happens when the entire window is OOB, we take a 0-slice of `x`. */ \
-    if (window_stop < window_start) {                          \
-      window_start = 0;                                        \
-      window_size = 0;                                         \
-    }                                                          \
-                                                               \
-    init_compact_seq(p_window, window_start, window_size, true);\
-                                                               \
-    slice_and_update_env(x, window, env, type, container);     \
-                                                               \
-    elt = R_forceAndCall(f_call, force, env);                  \
-    REPROTECT(elt, elt_prot_idx);                              \
-                                                               \
-    if (atomic && vec_size(elt) != 1) {                        \
-      stop_not_all_size_one(i + 1, vec_size(elt));             \
-    }                                                          \
-                                                               \
-    ASSIGN_ONE_FN(p_out, i, elt, ptype);                            \
-  }                                                            \
+#define SLIDE_LOOP(ASSIGN_ONE) do {                                            \
+  for (int i = iteration_min;                                                  \
+       i < iteration_max;                                                      \
+       i += step, start += start_step, stop += stop_step) {                    \
+                                                                               \
+    if (i % 1024 == 0) {                                                       \
+      R_CheckUserInterrupt();                                                  \
+    }                                                                          \
+                                                                               \
+    int window_start = max(start, 0);                                          \
+    int window_stop = min(stop, size - 1);                                     \
+    int window_size = window_stop - window_start + 1;                          \
+                                                                               \
+    /* Happens when the entire window is OOB, we take a 0-slice of `x`. */     \
+    if (window_stop < window_start) {                                          \
+      window_start = 0;                                                        \
+      window_size = 0;                                                         \
+    }                                                                          \
+                                                                               \
+    init_compact_seq(p_window, window_start, window_size, true);               \
+                                                                               \
+    slice_and_update_env(x, window, env, type, container);                     \
+                                                                               \
+    elt = r_force_eval(f_call, env, force);                                    \
+    REPROTECT(elt, elt_prot_idx);                                              \
+                                                                               \
+    if (atomic && vec_size(elt) != 1) {                                        \
+      stop_not_all_size_one(i + 1, vec_size(elt));                             \
+    }                                                                          \
+                                                                               \
+    ASSIGN_ONE(p_out, i, elt, ptype);                                          \
+  }                                                                            \
 } while(0)
 
-#define SLIDE_LOOP_ATOMIC(CTYPE, DEREF, ASSIGN_ONE_FN) do { \
-  CTYPE* p_out = DEREF(out);                                   \
-  SLIDE_LOOP(ASSIGN_ONE_FN);                                        \
-} while (0)                                                    \
+#define SLIDE_LOOP_ATOMIC(CTYPE, DEREF, ASSIGN_ONE) do { \
+  CTYPE* p_out = DEREF(out);                             \
+  SLIDE_LOOP(ASSIGN_ONE);                                \
+} while (0)                                              \
 
-#define SLIDE_LOOP_BARRIER(ASSIGN_ONE_FN) do {                      \
+#define SLIDE_LOOP_BARRIER(ASSIGN_ONE) do {                    \
   SEXP p_out = out;                                            \
                                                                \
-  /* Initialize with `NA`, not `NULL`, for size stability when auto-simplifying */ \
-  if (atomic && !constrain) {                                                      \
-    for (R_len_t i = 0; i < size; ++i) {                                           \
-      SET_VECTOR_ELT(p_out, i, slider_shared_na_lgl);                              \
-    }                                                                              \
-  }                                                                                \
+  /* Initialize with `NA`, not `NULL` */                       \
+  /* for size stability when auto-simplifying */               \
+  if (atomic && !constrain) {                                  \
+    for (R_len_t i = 0; i < size; ++i) {                       \
+      SET_VECTOR_ELT(p_out, i, slider_shared_na_lgl);          \
+    }                                                          \
+  }                                                            \
                                                                \
-  SLIDE_LOOP(ASSIGN_ONE_FN);                                        \
+  SLIDE_LOOP(ASSIGN_ONE);                                      \
 } while (0)
 
 // -----------------------------------------------------------------------------
@@ -165,23 +148,25 @@ SEXP slide_common_impl(SEXP x,
   SEXP container = PROTECT(make_slice_container(type));
 
   SEXPTYPE out_type = TYPEOF(ptype);
-
   SEXP out = PROTECT(Rf_allocVector(out_type, size));
 
   switch (out_type) {
-  case INTSXP: SLIDE_LOOP_ATOMIC(int, INTEGER, assign_one_int); break;
+  case INTSXP:  SLIDE_LOOP_ATOMIC(int, INTEGER, assign_one_int); break;
   case REALSXP: SLIDE_LOOP_ATOMIC(double, REAL, assign_one_dbl); break;
-  case LGLSXP: SLIDE_LOOP_ATOMIC(int, LOGICAL, assign_one_lgl); break;
-  case STRSXP: SLIDE_LOOP_ATOMIC(SEXP, STRING_PTR, assign_one_chr); break;
-  case VECSXP: SLIDE_LOOP_BARRIER(assign_one_lst); break;
+  case LGLSXP:  SLIDE_LOOP_ATOMIC(int, LOGICAL, assign_one_lgl); break;
+  case STRSXP:  SLIDE_LOOP_ATOMIC(SEXP, STRING_PTR, assign_one_chr); break;
+  case VECSXP:  SLIDE_LOOP_BARRIER(assign_one_lst); break;
   }
 
-  out = vec_restore(out, ptype);
-  PROTECT(out);
+  SEXP names = slider_names(x, type);
+  Rf_setAttrib(out, R_NamesSymbol, names);
 
-  out = copy_names(out, x, type);
-  PROTECT(out);
-
-  UNPROTECT(6);
+  UNPROTECT(4);
   return out;
 }
+
+// -----------------------------------------------------------------------------
+
+#undef SLIDE_LOOP
+#undef SLIDE_LOOP_ATOMIC
+#undef SLIDE_LOOP_BARRIER

--- a/src/slide.c
+++ b/src/slide.c
@@ -149,6 +149,7 @@ SEXP slide_common_impl(SEXP x,
   case LGLSXP:  SLIDE_LOOP_ATOMIC(int, LOGICAL, assign_one_lgl); break;
   case STRSXP:  SLIDE_LOOP_ATOMIC(SEXP, STRING_PTR, assign_one_chr); break;
   case VECSXP:  SLIDE_LOOP_BARRIER(assign_one_lst); break;
+  default:      never_reached("slide_common_impl");
   }
 
   SEXP names = slider_names(x, type);

--- a/src/slide.c
+++ b/src/slide.c
@@ -69,15 +69,13 @@ SEXP slide_common_impl(SEXP x,
                        SEXP params) {
 
   const int type = pull_type(params);
-
+  const int force = compute_force(type);
   const int size = compute_size(x, type);
 
   // Bail early if inputs are size 0
   if (size == 0) {
     return Rf_allocVector(TYPEOF(ptype), 0);
   }
-
-  const int force = compute_force(type);
 
   bool before_unbounded = false;
   bool after_unbounded = false;

--- a/src/slider-vctrs-private.c
+++ b/src/slider-vctrs-private.c
@@ -2,28 +2,20 @@
 
 // Experimental non-public vctrs functions
 SEXP (*vec_cast)(SEXP, SEXP) = NULL;
-SEXP (*vec_restore)(SEXP, SEXP) = NULL;
-SEXP (*vec_proxy)(SEXP) = NULL;
 SEXP (*vec_chop)(SEXP, SEXP) = NULL;
-SEXP (*vec_proxy_assign)(SEXP, SEXP, SEXP) = NULL;
 SEXP (*vec_slice_impl)(SEXP, SEXP) = NULL;
 SEXP (*vec_names)(SEXP) = NULL;
 SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
-SEXP (*vec_init)(SEXP, R_len_t) = NULL;
 SEXP (*compact_seq)(R_len_t, R_len_t, bool) = NULL;
 SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
 
 void slider_init_vctrs_private() {
   // Experimental non-public vctrs functions
   vec_cast = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_cast");
-  vec_restore = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_restore");
-  vec_proxy = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "exp_vec_proxy");
   vec_chop = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_chop");
-  vec_proxy_assign = (SEXP (*)(SEXP, SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_proxy_assign");
   vec_slice_impl = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_slice_impl");
   vec_names = (SEXP (*)(SEXP)) R_GetCCallable("vctrs", "exp_vec_names");
   vec_set_names = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_set_names");
-  vec_init = (SEXP (*)(SEXP, R_len_t)) R_GetCCallable("vctrs", "exp_short_vec_init");
   compact_seq = (SEXP (*)(R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "exp_short_compact_seq");
   init_compact_seq = (SEXP (*)(int*, R_len_t, R_len_t, bool)) R_GetCCallable("vctrs", "exp_short_init_compact_seq");
 }

--- a/src/slider-vctrs-private.h
+++ b/src/slider-vctrs-private.h
@@ -5,14 +5,10 @@
 
 // Experimental non-public vctrs functions
 extern SEXP (*vec_cast)(SEXP, SEXP);
-extern SEXP (*vec_restore)(SEXP, SEXP);
-extern SEXP (*vec_proxy)(SEXP);
 extern SEXP (*vec_chop)(SEXP, SEXP);
-extern SEXP (*vec_proxy_assign)(SEXP, SEXP, SEXP);
 extern SEXP (*vec_slice_impl)(SEXP, SEXP);
 extern SEXP (*vec_names)(SEXP);
 extern SEXP (*vec_set_names)(SEXP, SEXP);
-extern SEXP (*vec_init)(SEXP, R_len_t);
 extern SEXP (*compact_seq)(R_len_t, R_len_t, bool);
 extern SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -100,18 +100,21 @@ int compute_force(int type) {
 
 // -----------------------------------------------------------------------------
 
-SEXP copy_names(SEXP out, SEXP x, int type) {
-  SEXP names;
+SEXP slider_names(SEXP x, int type) {
   if (type == SLIDE) {
-    names = PROTECT(vec_names(x));
+    return vec_names(x);
   } else if (type == PSLIDE_EMPTY) {
-    names = PROTECT(R_NilValue);
+    return R_NilValue;
   } else {
-    names = PROTECT(vec_names(r_lst_get(x, 0)));
+    return vec_names(r_lst_get(x, 0));
   }
+}
 
+SEXP copy_names(SEXP out, SEXP x, int type) {
+  SEXP names = PROTECT(slider_names(x, type));
+  out = vec_set_names(out, names);
   UNPROTECT(1);
-  return vec_set_names(out, names);
+  return out;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/utils.c
+++ b/src/utils.c
@@ -110,13 +110,6 @@ SEXP slider_names(SEXP x, int type) {
   }
 }
 
-SEXP copy_names(SEXP out, SEXP x, int type) {
-  SEXP names = PROTECT(slider_names(x, type));
-  out = vec_set_names(out, names);
-  UNPROTECT(1);
-  return out;
-}
-
 // -----------------------------------------------------------------------------
 
 // `slice_and_update_env()` works by repeatedly overwriting the

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,14 @@ static inline int max(int x, int y) {
   return x > y ? x : y;
 }
 
+static inline SEXP r_force_eval(SEXP call, SEXP env, const int n_force) {
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 2, 3)
+  return R_forceAndCall(call, n_force, env);
+#else
+  return Rf_eval(call, env);
+#endif
+}
+
 static inline SEXP r_lst_get(SEXP x, int i) {
   return VECTOR_ELT(x, i);
 }
@@ -55,6 +63,7 @@ void check_hop_starts_not_past_stops(SEXP starts, SEXP stops);
 int compute_size(SEXP x, int type);
 int compute_force(int type);
 
+SEXP slider_names(SEXP x, int type);
 SEXP copy_names(SEXP out, SEXP x, int type);
 
 SEXP make_slice_container(int type);

--- a/src/utils.h
+++ b/src/utils.h
@@ -64,7 +64,6 @@ int compute_size(SEXP x, int type);
 int compute_force(int type);
 
 SEXP slider_names(SEXP x, int type);
-SEXP copy_names(SEXP out, SEXP x, int type);
 
 SEXP make_slice_container(int type);
 void slice_and_update_env(SEXP x, SEXP window, SEXP env, int type, SEXP container);

--- a/src/utils.h
+++ b/src/utils.h
@@ -39,6 +39,10 @@ static inline const char* r_scalar_chr_get(SEXP x) {
   return CHAR(STRING_ELT(x, 0));
 }
 
+__attribute__((noreturn)) static inline void never_reached(const char* fn) {
+  Rf_errorcall(R_NilValue, "Internal error: Reached the unreachable in `%s()`.", fn);
+}
+
 extern SEXP strings_dot_before;
 extern SEXP strings_dot_after;
 extern SEXP strings_dot_step;


### PR DESCRIPTION
Closes #99 

Now that #96 has been merged, we are now only doing the proxy-assign-restore loop in the case of the following base data types: dbl, int, lgl, chr, lst.

None of these will ever actually have a proxy, so we can actually refactor to remove the usage of `vec_proxy()`, `vec_restore()`, and `vec_proxy_assign()`, and instead use base R's C API to do the assignment.

This frees up vctrs to remove `vec_proxy_assign()` from the exported API. This is nice because it really is an internal tool in vctrs and probably shouldn't be exported.