### PR TITLE
Initialize vectors with `NA`

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,7 @@
   requireNamespace("vctrs", quietly = TRUE)
 
   # Initialize slider C globals
-  .Call(slider_init, ns_env("slider"))
+  .Call(slider_initialize, ns_env("slider"))
 }
 
 # nocov end

--- a/src/hop.c
+++ b/src/hop.c
@@ -90,7 +90,7 @@ SEXP hop_common_impl(SEXP x,
   const int* p_stops = INTEGER(stops);
 
   SEXPTYPE out_type = TYPEOF(ptype);
-  SEXP out = PROTECT(Rf_allocVector(out_type, size));
+  SEXP out = PROTECT(slider_init(out_type, size));
 
   switch (out_type) {
   case INTSXP:  HOP_LOOP_ATOMIC(int, INTEGER, assign_one_int); break;

--- a/src/index.c
+++ b/src/index.c
@@ -115,7 +115,7 @@ SEXP slide_index_common_impl(SEXP x,
   SEXP container = PROTECT_N(make_slice_container(type), &n_prot);
 
   SEXPTYPE out_type = TYPEOF(ptype);
-  SEXP out = PROTECT_N(Rf_allocVector(out_type, size), &n_prot);
+  SEXP out = PROTECT_N(slider_init(out_type, size), &n_prot);
 
   switch (out_type) {
   case INTSXP:  SLIDE_INDEX_LOOP_ATOMIC(int, INTEGER, assign_locs_int); break;
@@ -219,7 +219,7 @@ SEXP hop_index_common_impl(SEXP x,
   SEXP container = PROTECT_N(make_slice_container(type), &n_prot);
 
   SEXPTYPE out_type = TYPEOF(ptype);
-  SEXP out = PROTECT_N(Rf_allocVector(out_type, size), &n_prot);
+  SEXP out = PROTECT_N(slider_init(out_type, size), &n_prot);
 
   switch (out_type) {
   case INTSXP:  HOP_INDEX_LOOP_ATOMIC(int, INTEGER, assign_one_int); break;

--- a/src/init.c
+++ b/src/init.c
@@ -15,7 +15,7 @@ extern SEXP slider_vec_set_names(SEXP, SEXP);
 extern SEXP slider_vec_names(SEXP);
 
 // Defined below
-SEXP slider_init(SEXP);
+SEXP slider_initialize(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"slide_common_impl",         (DL_FUNC) &slide_common_impl, 5},
@@ -27,7 +27,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"slider_compute_to",         (DL_FUNC) &slider_compute_to, 4},
   {"slider_vec_set_names",      (DL_FUNC) &slider_vec_set_names, 2},
   {"slider_vec_names",          (DL_FUNC) &slider_vec_names, 1},
-  {"slider_init",               (DL_FUNC) &slider_init, 1},
+  {"slider_initialize",         (DL_FUNC) &slider_initialize, 1},
   {NULL, NULL, 0}
 };
 
@@ -38,17 +38,17 @@ void R_init_slider(DllInfo *dll)
 }
 
 // slider-vctrs-private.c
-void slider_init_vctrs_private();
+void slider_initialize_vctrs_private();
 
 // slider-vctrs-public.c
-void slider_init_vctrs_public();
+void slider_initialize_vctrs_public();
 
 // utils.c
-void slider_init_utils(SEXP);
+void slider_initialize_utils(SEXP);
 
-SEXP slider_init(SEXP ns) {
-  slider_init_vctrs_private();
-  slider_init_vctrs_public();
-  slider_init_utils(ns);
+SEXP slider_initialize(SEXP ns) {
+  slider_initialize_vctrs_private();
+  slider_initialize_vctrs_public();
+  slider_initialize_utils(ns);
   return R_NilValue;
 }

--- a/src/slide.c
+++ b/src/slide.c
@@ -136,7 +136,7 @@ SEXP slide_common_impl(SEXP x,
   SEXP container = PROTECT(make_slice_container(type));
 
   SEXPTYPE out_type = TYPEOF(ptype);
-  SEXP out = PROTECT(Rf_allocVector(out_type, size));
+  SEXP out = PROTECT(slider_init(out_type, size));
 
   switch (out_type) {
   case INTSXP:  SLIDE_LOOP_ATOMIC(int, INTEGER, assign_one_int); break;

--- a/src/slider-vctrs-private.c
+++ b/src/slider-vctrs-private.c
@@ -9,7 +9,7 @@ SEXP (*vec_set_names)(SEXP, SEXP) = NULL;
 SEXP (*compact_seq)(R_len_t, R_len_t, bool) = NULL;
 SEXP (*init_compact_seq)(int*, R_len_t, R_len_t, bool) = NULL;
 
-void slider_init_vctrs_private() {
+void slider_initialize_vctrs_private() {
   // Experimental non-public vctrs functions
   vec_cast = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_cast");
   vec_chop = (SEXP (*)(SEXP, SEXP)) R_GetCCallable("vctrs", "exp_vec_chop");

--- a/src/slider-vctrs-public.c
+++ b/src/slider-vctrs-public.c
@@ -1,5 +1,5 @@
 #include <vctrs.c>
 
-void slider_init_vctrs_public() {
+void slider_initialize_vctrs_public() {
   vctrs_init_api();
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,6 +21,39 @@ SEXP slider_ns_env = NULL;
 
 // -----------------------------------------------------------------------------
 
+#define SLIDER_INIT_ATOMIC(CTYPE, DEREF, NA_VALUE) do {        \
+  SEXP out = PROTECT(Rf_allocVector(type, size));              \
+  CTYPE* p_out = DEREF(out);                                   \
+                                                               \
+  for (R_xlen_t i = 0; i < size; ++i) {                        \
+    p_out[i] = NA_VALUE;                                       \
+  }                                                            \
+                                                               \
+  UNPROTECT(1);                                                \
+  return out;                                                  \
+} while (0)
+
+// Lists are initialized with `NULL` elements
+static SEXP list_init(R_xlen_t size) {
+  return Rf_allocVector(VECSXP, size);
+}
+
+SEXP slider_init(SEXPTYPE type, R_xlen_t size) {
+  switch (type) {
+  case LGLSXP:  SLIDER_INIT_ATOMIC(int, LOGICAL, NA_LOGICAL);
+  case INTSXP:  SLIDER_INIT_ATOMIC(int, INTEGER, NA_INTEGER);
+  case REALSXP: SLIDER_INIT_ATOMIC(double, REAL, NA_REAL);
+  case STRSXP:  SLIDER_INIT_ATOMIC(SEXP, STRING_PTR, NA_STRING);
+  case VECSXP:  return list_init(size);
+  default: Rf_errorcall(R_NilValue, "Internal error: Unknown type in `slider_init()`.");
+  }
+  never_reached("slider_init");
+}
+
+#undef SLIDER_INIT_ATOMIC
+
+// -----------------------------------------------------------------------------
+
 void stop_not_all_size_one(int iteration, int size) {
   SEXP call = PROTECT(
     Rf_lang3(

--- a/src/utils.c
+++ b/src/utils.c
@@ -174,7 +174,7 @@ void slice_and_update_env(SEXP x, SEXP window, SEXP env, int type, SEXP containe
 // -----------------------------------------------------------------------------
 
 // [[register()]]
-void slider_init_utils(SEXP ns) {
+void slider_initialize_utils(SEXP ns) {
   slider_ns_env = ns;
 
   syms_dot_x = Rf_install(".x");

--- a/src/utils.h
+++ b/src/utils.h
@@ -59,6 +59,8 @@ extern SEXP slider_shared_na_lgl;
 
 extern SEXP slider_ns_env;
 
+SEXP slider_init(SEXPTYPE type, R_xlen_t size);
+
 void stop_not_all_size_one(int iteration, int size);
 
 void check_slide_starts_not_past_stops(SEXP starts, SEXP stops);

--- a/tests/testthat/test-pslide-index-vec.R
+++ b/tests/testthat/test-pslide-index-vec.R
@@ -119,3 +119,14 @@ test_that("`pslide_index_vec()` falls back to `c()` method as required", {
   expect_identical(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x)), foobar(1:3))
   expect_condition(pslide_index_vec(list(1:3, 1:3), 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })
+
+# ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(pslide_index_int(list(1:3, 1:3), 1:3, ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(pslide_index_dbl(list(1:3, 1:3), 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(pslide_index_chr(list(1:3, 1:3), 1:3, ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(pslide_index_vec(list(1:3, 1:3), 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(pslide_index_vec(list(1:3, 1:3), 1:3, ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})

--- a/tests/testthat/test-pslide-vec.R
+++ b/tests/testthat/test-pslide-vec.R
@@ -117,3 +117,25 @@ test_that("`pslide_vec()` falls back to `c()` method as required", {
   expect_identical(pslide_vec(list(1:3, 1:3), ~foobar(.x)), foobar(1:3))
   expect_condition(pslide_vec(list(1:3, 1:3), ~foobar(.x)), class = "slider_c_foobar")
 })
+
+# ------------------------------------------------------------------------------
+# .step
+
+test_that(".step produces typed `NA` values", {
+  expect_identical(pslide_int(list(1:3, 1:3), ~.x, .step = 2), c(1L, NA, 3L))
+  expect_identical(pslide_dbl(list(1:3, 1:3), ~.x, .step = 2), c(1, NA, 3))
+  expect_identical(pslide_chr(list(c("a", "b", "c"), 1:3), ~.x, .step = 2), c("a", NA, "c"))
+  expect_identical(pslide_vec(list(1:3, 1:3), ~.x, .step = 2), c(1L, NA, 3L))
+  expect_identical(pslide_vec(list(1:3, 1:3), ~.x, .step = 2, .ptype = integer()), c(1L, NA, 3L))
+})
+
+# ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(pslide_int(list(1:3, 1:3), ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(pslide_dbl(list(1:3, 1:3), ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(pslide_chr(list(1:3, 1:3), ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(pslide_vec(list(1:3, 1:3), ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(pslide_vec(list(1:3, 1:3), ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})

--- a/tests/testthat/test-slide-index-vec.R
+++ b/tests/testthat/test-slide-index-vec.R
@@ -98,6 +98,17 @@ test_that("`slide_index_vec()` falls back to `c()` method as required", {
 })
 
 # ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(slide_index_int(1:3, 1:3, ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(slide_index_dbl(1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_index_chr(1:3, 1:3, ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(slide_index_vec(1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_index_vec(1:3, 1:3, ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})
+
+# ------------------------------------------------------------------------------
 # suffix tests
 
 test_that("slide_index_int() works", {

--- a/tests/testthat/test-slide-index2-vec.R
+++ b/tests/testthat/test-slide-index2-vec.R
@@ -112,3 +112,14 @@ test_that("`slide_index2_vec()` falls back to `c()` method as required", {
   expect_identical(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x)), foobar(1:3))
   expect_condition(slide_index2_vec(1:3, 1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })
+
+# ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(slide_index2_int(1:3, 1:3, 1:3, ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(slide_index2_dbl(1:3, 1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_index2_chr(1:3, 1:3, 1:3, ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(slide_index2_vec(1:3, 1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_index2_vec(1:3, 1:3, 1:3, ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})

--- a/tests/testthat/test-slide-vec.R
+++ b/tests/testthat/test-slide-vec.R
@@ -101,6 +101,28 @@ test_that("`slide_vec()` falls back to `c()` method as required", {
 })
 
 # ------------------------------------------------------------------------------
+# .step
+
+test_that(".step produces typed `NA` values", {
+  expect_identical(slide_int(1:3, identity, .step = 2), c(1L, NA, 3L))
+  expect_identical(slide_dbl(1:3, identity, .step = 2), c(1, NA, 3))
+  expect_identical(slide_chr(c("a", "b", "c"), identity, .step = 2), c("a", NA, "c"))
+  expect_identical(slide_vec(1:3, identity, .step = 2), c(1L, NA, 3L))
+  expect_identical(slide_vec(1:3, identity, .step = 2, .ptype = integer()), c(1L, NA, 3L))
+})
+
+# ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(slide_int(1:3, ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(slide_dbl(1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_chr(1:3, ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(slide_vec(1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide_vec(1:3, ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})
+
+# ------------------------------------------------------------------------------
 # input names
 
 test_that("names exist on inner sliced elements", {

--- a/tests/testthat/test-slide2-vec.R
+++ b/tests/testthat/test-slide2-vec.R
@@ -118,3 +118,25 @@ test_that("`slide2_vec()` falls back to `c()` method as required", {
   expect_identical(slide2_vec(1:3, 1:3, ~foobar(.x)), foobar(1:3))
   expect_condition(slide2_vec(1:3, 1:3, ~foobar(.x)), class = "slider_c_foobar")
 })
+
+# ------------------------------------------------------------------------------
+# .step
+
+test_that(".step produces typed `NA` values", {
+  expect_identical(slide2_int(1:3, 1:3, ~.x, .step = 2), c(1L, NA, 3L))
+  expect_identical(slide2_dbl(1:3, 1:3, ~.x, .step = 2), c(1, NA, 3))
+  expect_identical(slide2_chr(c("a", "b", "c"), 1:3, ~.x, .step = 2), c("a", NA, "c"))
+  expect_identical(slide2_vec(1:3, 1:3, ~.x, .step = 2), c(1L, NA, 3L))
+  expect_identical(slide2_vec(1:3, 1:3, ~.x, .step = 2, .ptype = integer()), c(1L, NA, 3L))
+})
+
+# ------------------------------------------------------------------------------
+# .complete
+
+test_that(".complete produces typed `NA` values", {
+  expect_identical(slide2_int(1:3, 1:3, ~1L, .before = 1, .complete = TRUE), c(NA, 1L, 1L))
+  expect_identical(slide2_dbl(1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide2_chr(1:3, 1:3, ~"1", .before = 1, .complete = TRUE), c(NA, "1", "1"))
+  expect_identical(slide2_vec(1:3, 1:3, ~1, .before = 1, .complete = TRUE), c(NA, 1, 1))
+  expect_identical(slide2_vec(1:3, 1:3, ~1, .before = 1, .complete = TRUE, .ptype = integer()), c(NA, 1L, 1L))
+})


### PR DESCRIPTION
To avoid garbage when `.skip` or `.complete` is used. Found when doing revdepchecks on feasts. New tests have been added.