### PR TITLE
Remove remaining early exits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # slider (development version)
 
+* As a followup to a change in slider 0.1.3, edge cases with size zero input
+  in `hop()` have also been fixed.
+  
 * C code has been refactored to be less reliant on vctrs internals.
 
 # slider 0.1.3

--- a/R/hop-common.R
+++ b/R/hop-common.R
@@ -10,12 +10,6 @@ hop_common <- function(x, starts, stops, f_call, ptype, env, type, constrain, at
   size <- vec_size_common(starts, stops)
   args <- vec_recycle_common(starts, stops, .size = size)
 
-  # Early exit if empty input
-  # (but after all size checks have been done)
-  if (size == 0L) {
-    return(vec_init(ptype, 0L))
-  }
-
   starts <- args[[1L]]
   stops <- args[[2L]]
 

--- a/R/hop-common.R
+++ b/R/hop-common.R
@@ -16,10 +16,6 @@ hop_common <- function(x, starts, stops, f_call, ptype, env, type, constrain, at
     return(vec_init(ptype, 0L))
   }
 
-  if (x_size == 0L) {
-    return(vec_init(ptype, size))
-  }
-
   starts <- args[[1L]]
   stops <- args[[2L]]
 

--- a/tests/testthat/test-hop.R
+++ b/tests/testthat/test-hop.R
@@ -19,7 +19,7 @@ test_that("empty input returns a list", {
 })
 
 test_that("empty `.x`, but size `n > 0` `.starts` and `.stops` returns size `n` empty ptype", {
-  expect_equal(hop(integer(), 1:2, 2:3, ~.x), list(NULL, NULL))
+  expect_equal(hop(integer(), 1:2, 2:3, ~.x), list(integer(), integer()))
 })
 
 test_that("empty `.x`, but size `n > 0` `.starts` and `.stops`: sizes and types are checked first", {

--- a/tests/testthat/test-hop2.R
+++ b/tests/testthat/test-hop2.R
@@ -5,7 +5,7 @@ test_that("Recycling is carried out using tidyverse recycling rules", {
   x3 <- c(3L, 3L, 3L)
 
   expect_equal(hop2(x0, x0, integer(), integer(), ~.x), list())
-  expect_equal(hop2(x0, x1, 1, 1, ~.x), list(NULL))
+  expect_equal(hop2(x0, x1, 1, 1, ~.x), list(integer()))
   expect_equal(hop2(x0, x1, integer(), integer(), ~.x), list())
   expect_error(hop2(x0, x2, 1:2, 1:2, ~.x), class = "vctrs_error_incompatible_size")
   expect_equal(hop2(x1, x1, 1, 1, ~.x), list(x1))

--- a/tests/testthat/test-phop.R
+++ b/tests/testthat/test-phop.R
@@ -10,9 +10,9 @@ test_that("Recycling is carried out using tidyverse recycling rules", {
   x3 <- c(3L, 3L, 3L)
 
   expect_equal(phop(list(x0, x0), integer(), integer(), ~.x), list())
-  expect_equal(phop(list(x0, x0), 1, 1, ~.x), list(NULL))
+  expect_equal(phop(list(x0, x0), 1, 1, ~.x), list(integer()))
   expect_equal(phop(list(x0, x1), integer(), integer(), ~.x), list())
-  expect_equal(phop(list(x0, x1), 1, 1, ~.x), list(NULL))
+  expect_equal(phop(list(x0, x1), 1, 1, ~.x), list(integer()))
   expect_error(phop(list(x0, x2), 1, 1, ~.x), class = "vctrs_error_incompatible_size")
   expect_equal(phop(list(x1, x1), 1, 1, ~.x), list(x1))
   expect_equal(phop(list(x1, x2), 1:2, 1:2, ~.x), list(x1, x1))


### PR DESCRIPTION
I missed the early exit in `hop()`, which is no longer needed. Tests have been updated to reflect the more correct semantics that `hop_index()` already has