### PR TITLE
link to "current" Postgres docs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -200,7 +200,7 @@ Otherwise, like `purrr::map()`, `slide()` is optimized in C to be as fast as pos
 
 I've found the following references very useful to understand more about window functions:
 
-- [Postgres SQL documentation](https://www.postgresql.org/docs/9.1/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS)
+- [Postgres SQL documentation](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS)
 
 - [dbplyr window function vignette](https://dbplyr.tidyverse.org/articles/translation-function.html#window-functions)
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ I’ve found the following references very useful to understand more about
 window functions:
 
   - [Postgres SQL
-    documentation](https://www.postgresql.org/docs/9.1/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS)
+    documentation](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS)
 
   - [dbplyr window function
     vignette](https://dbplyr.tidyverse.org/articles/translation-function.html#window-functions)


### PR DESCRIPTION
This changes the link to the Postgres docs from the now unsupported version 9.1 to the "current" version.