### PR TITLE
Ensure that generated endpoints are castable to `.i`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@
 * The `slide_index_*()` family has undergone some internal changes to make it
   more compatible with custom vctrs classes that could be provided as the
   index (`.i`), such as the date-time classes in the clock package (#133, #130).
+  
+* For the `slide_index_*()` family, it is now required that `.i - .before` and
+  `.i + .after` be castable to `.i` by `vctrs::vec_cast()`. Similarly, for
+  the `hop_index_*()` family, `.starts` and `.stops` must both be castable to
+  `.i` (#132).
 
 * `vignette("rowwise")` has been updated to use `cur_data()` from dplyr 1.0.0,
   which makes it significantly easier to do rolling operations on data frames

--- a/R/hop-index-common.R
+++ b/R/hop-index-common.R
@@ -31,10 +31,13 @@ hop_index_common <- function(x,
   i <- unrep$key
   peer_sizes <- unrep$times
 
+  starts <- vec_cast(starts, i, x_arg = ".starts", to_arg = ".i")
+  stops <- vec_cast(stops, i, x_arg = ".stops", to_arg = ".i")
+
   size <- vec_size_common(starts, stops)
   args <- vec_recycle_common(starts = starts, stops = stops, .size = size)
-  args <- vec_cast_common(i = i, !!!args)
-  args <- compute_combined_ranks(!!!args)
+
+  args <- compute_combined_ranks(i = i, !!!args)
 
   i <- args$i
   starts <- args$starts

--- a/R/slide-index-common.R
+++ b/R/slide-index-common.R
@@ -79,6 +79,7 @@ compute_ranges <- function(i, before, after, i_arg, before_arg, after_arg) {
     starts <- NULL
   } else {
     starts <- i - before
+    starts <- vec_cast(starts, i, to_arg = ".i")
     check_generated_endpoints_cannot_be_na(starts, before_arg)
   }
 
@@ -86,6 +87,7 @@ compute_ranges <- function(i, before, after, i_arg, before_arg, after_arg) {
     stops <- NULL
   } else {
     stops <- i + after
+    stops <- vec_cast(stops, i, to_arg = ".i")
     check_generated_endpoints_cannot_be_na(stops, after_arg)
   }
 

--- a/tests/testthat/test-hop-index.R
+++ b/tests/testthat/test-hop-index.R
@@ -89,16 +89,14 @@ test_that("0 length .starts/.stops are allowed", {
   expect_equal(hop_index(1, 1, integer(), integer(), ~.x), list())
 })
 
-test_that("common type is found among .i/.starts/.stops", {
+test_that(".starts and .stops are cast to .i", {
   i <- new_date(c(0, 1))
-  start <- vec_cast(i[1], new_datetime(0))
-  stop <- i[2]
+  starts <- c("x", "y")
+  stops <- i
 
-  expect_equal(
-    hop_index(1:2, i, start, stop, ~.x),
-    list(
-      1:2
-    )
+  expect_error(
+    hop_index(1:2, i, starts, stops, ~.x),
+    class = "vctrs_error_incompatible_type"
   )
 })
 

--- a/tests/testthat/test-slide-index.R
+++ b/tests/testthat/test-slide-index.R
@@ -216,8 +216,8 @@ test_that("can define ranges based on an irregular numeric index", {
 # ------------------------------------------------------------------------------
 # .before - lubridate - Durations
 
-test_that("can use hour Durations with Dates", {
-  i <- new_date(c(0, 1, 2, 3))
+test_that("can use hour Durations with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_equal(
@@ -232,27 +232,27 @@ test_that("can use hour Durations with Dates", {
 
   expect_equal(
     slide_index(x, i, identity, .before = lubridate::dhours(24)),
-    slide_index(x, i, identity, .before = 1L)
+    slide_index(x, i, identity, .before = 24 * 60 * 60)
   )
 })
 
-test_that("can use day Durations with Dates", {
-  i <- new_date(c(0, 1, 2, 3))
+test_that("can use day Durations with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_equal(
     slide_index(x, i, identity, .before = lubridate::ddays(1)),
-    slide_index(x, i, identity, .before = 1L)
+    slide_index(x, i, identity, .before = 24 * 60 * 60)
   )
 
   expect_equal(
     slide_index(x, i, identity, .before = lubridate::ddays(2)),
-    slide_index(x, i, identity, .before = 2L)
+    slide_index(x, i, identity, .before = 2 * 24 * 60 * 60)
   )
 })
 
-test_that("can use week Durations with Dates", {
-  i <- new_date(c(0, 6, 7, 8))
+test_that("can use week Durations with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 6, 7, 8)))
   x <- seq_along(i)
   before <- lubridate::dweeks(1)
 
@@ -268,8 +268,8 @@ test_that("can use week Durations with Dates", {
   )
 })
 
-test_that("can use year Durations with Dates", {
-  i <- new_date(c(0, 365, 365 * 2))
+test_that("can use year Durations with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 365, 365 * 2)))
   x <- seq_along(i)
   before <- lubridate::dyears(1)
 
@@ -283,8 +283,8 @@ test_that("can use year Durations with Dates", {
   )
 })
 
-test_that("can use negative Durations with Dates", {
-  i <- new_date(c(0, 1, 2, 3))
+test_that("can use negative Durations with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_equal(
@@ -309,7 +309,7 @@ test_that("can use negative Durations with Dates", {
 })
 
 test_that("errors if negative .before Duration is further than .after", {
-  i <- new_date(c(0, 1, 2, 3))
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_error(
@@ -348,26 +348,11 @@ test_that("can use second Durations with POSIXct", {
   )
 })
 
-test_that("can use day Durations with POSIXct", {
-  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
-  x <- seq_along(i)
-
-  expect_equal(
-    slide_index(x, i, identity, .before = lubridate::ddays(1)),
-    list(
-      1L,
-      1:2,
-      2:3,
-      3:4
-    )
-  )
-})
-
 # ------------------------------------------------------------------------------
 # .before - lubridate - Periods
 
-test_that("can use hour Periods with Dates", {
-  i <- new_date(c(0, 1, 2, 3))
+test_that("can use hour Periods with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_equal(
@@ -382,7 +367,12 @@ test_that("can use hour Periods with Dates", {
 
   expect_equal(
     slide_index(x, i, identity, .before = lubridate::hours(24)),
-    slide_index(x, i, identity, .before = 1L)
+    list(
+      1L,
+      1:2,
+      2:3,
+      3:4
+    )
   )
 })
 
@@ -420,6 +410,7 @@ test_that("can use week Periods with Dates", {
 
   # If you want to avoid that 1 week prior data point, bump it back
   # to 1 week - 1 second
+  i <- lubridate::as_datetime(i)
   before <- lubridate::weeks(1) - lubridate::seconds(1)
 
   expect_equal(
@@ -464,7 +455,7 @@ test_that("can generally use (tricky!) month Periods with Dates", {
 
 test_that("can use year Durations/Periods with Dates and leap years", {
   # 2008 = leap year
-  i <- as.Date(c("2008-01-01", "2009-01-01", "2010-01-01"))
+  i <- as.POSIXct(c("2008-01-01", "2009-01-01", "2010-01-01"), "UTC")
   x <- seq_along(i)
   before <- lubridate::dyears(1)
 
@@ -721,8 +712,8 @@ test_that("can define ranges based on an irregular numeric index", {
 # ------------------------------------------------------------------------------
 # .after - lubridate - Periods
 
-test_that("can use hour Periods with Dates", {
-  i <- new_date(c(0, 1, 2, 3))
+test_that("can use hour Periods with POSIXct", {
+  i <- lubridate::as_datetime(new_date(c(0, 1, 2, 3)))
   x <- seq_along(i)
 
   expect_equal(
@@ -737,7 +728,12 @@ test_that("can use hour Periods with Dates", {
 
   expect_equal(
     slide_index(x, i, identity, .after = lubridate::hours(24)),
-    slide_index(x, i, identity, .after = 1L)
+    list(
+      1:2,
+      2:3,
+      3:4,
+      4L
+    )
   )
 })
 
@@ -775,6 +771,7 @@ test_that("can use week Periods with Dates", {
 
   # If you want to avoid that 1 week prior data point, bump it back
   # to 1 week - 1 second
+  i <- lubridate::as_datetime(i)
   after <- lubridate::weeks(1) - lubridate::seconds(1)
 
   expect_equal(
@@ -1098,17 +1095,6 @@ test_that("names are retained on inner sliced object", {
 # ------------------------------------------------------------------------------
 # .i types
 
-test_that("can technically use a logical index", {
-  expect_equal(
-    slide_index(1:3, c(FALSE, FALSE, TRUE), ~.x, .before = 1L),
-    list(
-      1:2,
-      1:2,
-      1:3
-    )
-  )
-})
-
 test_that("can use a data frame index", {
   expect_equal(
     slide_index(1:5, data.frame(x = c(1, 1, 2, 3, 4)), ~.x),
@@ -1119,6 +1105,24 @@ test_that("can use a data frame index", {
       4L,
       5L
     )
+  )
+})
+
+test_that("`.i - .before` must be castable to `.i`", {
+  i <- 1L
+
+  expect_error(
+    slide_index(1, i, identity, .before = 1.5),
+    class = "vctrs_error_cast_lossy"
+  )
+})
+
+test_that("`.i + .after` must be castable to `.i`", {
+  i <- 1L
+
+  expect_error(
+    slide_index(1, i, identity, .after = 1.5),
+    class = "vctrs_error_cast_lossy"
   )
 })
 


### PR DESCRIPTION
Closes #132 