### PR TITLE
Alignment fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+SystemRequirements: C11
 Collate: 
     'block.R'
     'conditions.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-SystemRequirements: C11
+SystemRequirements: C++11
 Collate: 
     'block.R'
     'conditions.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # slider (development version)
 
+* Fixed a C alignment issue detected by CRAN's USBAN machine related to
+  allocating vectors of `long double`.
+
 * Fixed a test that relied too strongly on the size of the C type,
   `long double`, which can vary across platforms (#147).
 

--- a/src/align.h
+++ b/src/align.h
@@ -1,0 +1,45 @@
+#ifndef SLIDER_ALIGN_H
+#define SLIDER_ALIGN_H
+
+/*
+ * Following guidance of:
+ * https://stackoverflow.com/questions/227897/how-to-allocate-aligned-memory-only-using-the-standard-library
+ *
+ * 1) Allocate enough space to shift the pointer
+ * 2) Add to the pointer (p_x + buffer)
+ * 3) Round down to the closest boundary using `& mask`
+ */
+
+#include "slider.h"
+#include <stdint.h> // uintptr_t
+
+/*
+ * This include requires C11. It contains `alignof()`, which isn't directly
+ * used by this file, but is used by any consumers of this file to provide
+ * the `element_align` parameters.
+ */
+#include <stdalign.h>
+
+static
+inline
+SEXP
+aligned_allocate(R_xlen_t n_elements,
+                 size_t element_size,
+                 size_t element_align) {
+  const size_t buffer = element_align - 1;
+  const R_xlen_t size = n_elements * element_size + buffer;
+  return Rf_allocVector(RAWSXP, size);
+}
+
+static
+inline
+void*
+aligned_void_deref(SEXP x, size_t element_align) {
+  const size_t buffer = element_align - 1;
+  uintptr_t mask = ~ (uintptr_t)buffer;
+  uintptr_t p_x = (uintptr_t)RAW(x);
+  uintptr_t p_aligned = (p_x + buffer) & mask;
+  return (void*) p_aligned;
+}
+
+#endif

--- a/src/align.h
+++ b/src/align.h
@@ -13,13 +13,6 @@
 #include "slider.h"
 #include <stdint.h> // uintptr_t
 
-/*
- * This include requires C11. It contains `alignof()`, which isn't directly
- * used by this file, but is used by any consumers of this file to provide
- * the `element_align` parameters.
- */
-#include <stdalign.h>
-
 static
 inline
 SEXP

--- a/src/segment-tree.c
+++ b/src/segment-tree.c
@@ -11,6 +11,7 @@ struct segment_tree new_segment_tree(uint64_t n_leaves,
                                      void (*state_finalize)(void* p_state, void* p_result),
                                      void* (*nodes_increment)(void* p_nodes),
                                      SEXP (*nodes_initialize)(uint64_t n),
+                                     void* (*nodes_void_deref)(SEXP nodes),
                                      void (*aggregate_from_leaves)(const void* p_source, uint64_t begin, uint64_t end, void* p_dest),
                                      void (*aggregate_from_nodes)(const void* p_source, uint64_t begin, uint64_t end, void* p_dest)) {
   struct segment_tree tree;
@@ -33,7 +34,7 @@ struct segment_tree new_segment_tree(uint64_t n_leaves,
   tree.p_p_level = (void**) RAW(tree.p_level);
 
   tree.nodes = PROTECT(nodes_initialize(tree.n_nodes));
-  tree.p_nodes = r_deref(tree.nodes, TYPEOF(tree.nodes));
+  tree.p_nodes = nodes_void_deref(tree.nodes);
 
   tree.state_reset = state_reset;
   tree.state_finalize = state_finalize;

--- a/src/segment-tree.h
+++ b/src/segment-tree.h
@@ -44,6 +44,7 @@ struct segment_tree new_segment_tree(uint64_t n_leaves,
                                      void (*state_finalize)(void* p_state, void* p_result),
                                      void* (*nodes_increment)(void* p_nodes),
                                      SEXP (*nodes_initialize)(uint64_t n),
+                                     void* (*nodes_void_deref)(SEXP nodes),
                                      void (*aggregate_from_leaves)(const void* p_source, uint64_t begin, uint64_t end, void* p_dest),
                                      void (*aggregate_from_nodes)(const void* p_source, uint64_t begin, uint64_t end, void* p_dest));
 

--- a/src/summary-core-align.cpp
+++ b/src/summary-core-align.cpp
@@ -1,0 +1,21 @@
+#include "summary-core-align.h"
+
+extern "C" {
+
+/*
+ * `alignof()` is C++11 specific, so this single compilation unit requires
+ * C++11, and we call these helpers from C in `summary-core.h`.
+ *
+ * Technically `alignof()` is also in C11, but it is unclear how well R supports
+ * that.
+ */
+
+size_t align_of_long_double() {
+  return alignof(long double);
+}
+
+size_t align_of_mean_state_t() {
+  return alignof(struct mean_state_t);
+}
+
+} // extern "C"

--- a/src/summary-core-align.h
+++ b/src/summary-core-align.h
@@ -1,0 +1,15 @@
+#ifndef SLIDER_SUMMARY_CORE_ALIGN
+#define SLIDER_SUMMARY_CORE_ALIGN
+
+#include <stddef.h> // size_t
+
+extern "C" {
+
+#include "summary-core-types.h"
+
+size_t align_of_long_double();
+size_t align_of_mean_state_t();
+
+} // extern "C"
+
+#endif

--- a/src/summary-core-types.h
+++ b/src/summary-core-types.h
@@ -1,0 +1,11 @@
+#ifndef SLIDER_SUMMARY_CORE_TYPES
+#define SLIDER_SUMMARY_CORE_TYPES
+
+#include <stdint.h> // uintptr_t
+
+struct mean_state_t {
+  long double sum;
+  uint64_t count;
+};
+
+#endif

--- a/src/summary-core.h
+++ b/src/summary-core.h
@@ -2,7 +2,12 @@
 #define SLIDER_SUMMARY_CORE
 
 #include "slider.h"
+#include "summary-core-types.h"
 #include "align.h"
+
+// From `summary-core-align.hpp`
+size_t align_of_long_double();
+size_t align_of_mean_state_t();
 
 // -----------------------------------------------------------------------------
 // Sum
@@ -32,14 +37,14 @@ static inline void* sum_nodes_increment(void* p_nodes) {
 }
 
 static inline void* sum_nodes_void_deref(SEXP nodes) {
-  return aligned_void_deref(nodes, alignof(long double));
+  return aligned_void_deref(nodes, align_of_long_double());
 }
 static inline long double* sum_nodes_deref(SEXP nodes) {
   return (long double*) sum_nodes_void_deref(nodes);
 }
 
 static inline SEXP sum_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), alignof(long double)));
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), align_of_long_double()));
   long double* p_nodes = sum_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
@@ -160,14 +165,14 @@ static inline void* prod_nodes_increment(void* p_nodes) {
 }
 
 static inline void* prod_nodes_void_deref(SEXP nodes) {
-  return aligned_void_deref(nodes, alignof(long double));
+  return aligned_void_deref(nodes, align_of_long_double());
 }
 static inline long double* prod_nodes_deref(SEXP nodes) {
   return (long double*) prod_nodes_void_deref(nodes);
 }
 
 static inline SEXP prod_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), alignof(long double)));
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), align_of_long_double()));
   long double* p_nodes = prod_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
@@ -263,11 +268,6 @@ static inline void prod_na_rm_aggregate_from_nodes(const void* p_source,
 // -----------------------------------------------------------------------------
 // Mean
 
-struct mean_state_t {
-  long double sum;
-  uint64_t count;
-};
-
 static inline void mean_state_reset(void* p_state) {
   struct mean_state_t* p_state_ = (struct mean_state_t*) p_state;
   p_state_->sum = 0;
@@ -286,14 +286,14 @@ static inline void* mean_nodes_increment(void* p_nodes) {
 }
 
 static inline void* mean_nodes_void_deref(SEXP nodes) {
-  return aligned_void_deref(nodes, alignof(struct mean_state_t));
+  return aligned_void_deref(nodes, align_of_mean_state_t());
 }
 static inline struct mean_state_t* mean_nodes_deref(SEXP nodes) {
   return (struct mean_state_t*) mean_nodes_void_deref(nodes);
 }
 
 static inline SEXP mean_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(struct mean_state_t), alignof(struct mean_state_t)));
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(struct mean_state_t), align_of_mean_state_t()));
   struct mean_state_t* p_nodes = mean_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {

--- a/src/summary-core.h
+++ b/src/summary-core.h
@@ -2,6 +2,7 @@
 #define SLIDER_SUMMARY_CORE
 
 #include "slider.h"
+#include "align.h"
 
 // -----------------------------------------------------------------------------
 // Sum
@@ -30,9 +31,16 @@ static inline void* sum_nodes_increment(void* p_nodes) {
   return (void*) (((long double*) p_nodes) + 1);
 }
 
+static inline void* sum_nodes_void_deref(SEXP nodes) {
+  return aligned_void_deref(nodes, alignof(long double));
+}
+static inline long double* sum_nodes_deref(SEXP nodes) {
+  return (long double*) sum_nodes_void_deref(nodes);
+}
+
 static inline SEXP sum_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(Rf_allocVector(RAWSXP, n * sizeof(long double)));
-  long double* p_nodes = (long double*) RAW(nodes);
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), alignof(long double)));
+  long double* p_nodes = sum_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = 0;
@@ -151,9 +159,16 @@ static inline void* prod_nodes_increment(void* p_nodes) {
   return (void*) (((long double*) p_nodes) + 1);
 }
 
+static inline void* prod_nodes_void_deref(SEXP nodes) {
+  return aligned_void_deref(nodes, alignof(long double));
+}
+static inline long double* prod_nodes_deref(SEXP nodes) {
+  return (long double*) prod_nodes_void_deref(nodes);
+}
+
 static inline SEXP prod_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(Rf_allocVector(RAWSXP, n * sizeof(long double)));
-  long double* p_nodes = (long double*) RAW(nodes);
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(long double), alignof(long double)));
+  long double* p_nodes = prod_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = 1;
@@ -270,9 +285,16 @@ static inline void* mean_nodes_increment(void* p_nodes) {
   return (void*) (((struct mean_state_t*) p_nodes) + 1);
 }
 
+static inline void* mean_nodes_void_deref(SEXP nodes) {
+  return aligned_void_deref(nodes, alignof(struct mean_state_t));
+}
+static inline struct mean_state_t* mean_nodes_deref(SEXP nodes) {
+  return (struct mean_state_t*) mean_nodes_void_deref(nodes);
+}
+
 static inline SEXP mean_nodes_initialize(uint64_t n) {
-  SEXP nodes = PROTECT(Rf_allocVector(RAWSXP, n * sizeof(struct mean_state_t)));
-  struct mean_state_t* p_nodes = (struct mean_state_t*) RAW(nodes);
+  SEXP nodes = PROTECT(aligned_allocate(n, sizeof(struct mean_state_t), alignof(struct mean_state_t)));
+  struct mean_state_t* p_nodes = mean_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i].sum = 0;
@@ -388,9 +410,16 @@ static inline void* min_nodes_increment(void* p_nodes) {
   return (void*) (((double*) p_nodes) + 1);
 }
 
+static inline double* min_nodes_deref(SEXP nodes) {
+  return REAL(nodes);
+}
+static inline void* min_nodes_void_deref(SEXP nodes) {
+  return (void*) min_nodes_deref(nodes);
+}
+
 static inline SEXP min_nodes_initialize(uint64_t n) {
   SEXP nodes = PROTECT(Rf_allocVector(REALSXP, n));
-  double* p_nodes = REAL(nodes);
+  double* p_nodes = min_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = R_PosInf;
@@ -473,9 +502,16 @@ static inline void* max_nodes_increment(void* p_nodes) {
   return (void*) (((double*) p_nodes) + 1);
 }
 
+static inline double* max_nodes_deref(SEXP nodes) {
+  return REAL(nodes);
+}
+static inline void* max_nodes_void_deref(SEXP nodes) {
+  return (void*) max_nodes_deref(nodes);
+}
+
 static inline SEXP max_nodes_initialize(uint64_t n) {
   SEXP nodes = PROTECT(Rf_allocVector(REALSXP, n));
-  double* p_nodes = REAL(nodes);
+  double* p_nodes = max_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = R_NegInf;
@@ -558,9 +594,16 @@ static inline void* all_nodes_increment(void* p_nodes) {
   return (void*) (((int*) p_nodes) + 1);
 }
 
+static inline int* all_nodes_deref(SEXP nodes) {
+  return LOGICAL(nodes);
+}
+static inline void* all_nodes_void_deref(SEXP nodes) {
+  return (void*) all_nodes_deref(nodes);
+}
+
 static inline SEXP all_nodes_initialize(uint64_t n) {
   SEXP nodes = PROTECT(Rf_allocVector(LGLSXP, n));
-  int* p_nodes = LOGICAL(nodes);
+  int* p_nodes = all_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = 1;
@@ -653,9 +696,16 @@ static inline void* any_nodes_increment(void* p_nodes) {
   return (void*) (((int*) p_nodes) + 1);
 }
 
+static inline int* any_nodes_deref(SEXP nodes) {
+  return LOGICAL(nodes);
+}
+static inline void* any_nodes_void_deref(SEXP nodes) {
+  return (void*) any_nodes_deref(nodes);
+}
+
 static inline SEXP any_nodes_initialize(uint64_t n) {
   SEXP nodes = PROTECT(Rf_allocVector(LGLSXP, n));
-  int* p_nodes = LOGICAL(nodes);
+  int* p_nodes = any_nodes_deref(nodes);
 
   for (uint64_t i = 0; i < n; ++i) {
     p_nodes[i] = 0;

--- a/src/summary-index.c
+++ b/src/summary-index.c
@@ -216,6 +216,7 @@ static void slider_index_sum_core_impl(const double* p_x,
     sum_state_finalize,
     sum_nodes_increment,
     sum_nodes_initialize,
+    sum_nodes_void_deref,
     na_rm ? sum_na_rm_aggregate_from_leaves : sum_na_keep_aggregate_from_leaves,
     na_rm ? sum_na_rm_aggregate_from_nodes : sum_na_keep_aggregate_from_nodes
   );
@@ -300,6 +301,7 @@ static void slider_index_prod_core_impl(const double* p_x,
     prod_state_finalize,
     prod_nodes_increment,
     prod_nodes_initialize,
+    prod_nodes_void_deref,
     na_rm ? prod_na_rm_aggregate_from_leaves : prod_na_keep_aggregate_from_leaves,
     na_rm ? prod_na_rm_aggregate_from_nodes : prod_na_keep_aggregate_from_nodes
   );
@@ -384,6 +386,7 @@ static void slider_index_mean_core_impl(const double* p_x,
     mean_state_finalize,
     mean_nodes_increment,
     mean_nodes_initialize,
+    mean_nodes_void_deref,
     na_rm ? mean_na_rm_aggregate_from_leaves : mean_na_keep_aggregate_from_leaves,
     na_rm ? mean_na_rm_aggregate_from_nodes : mean_na_keep_aggregate_from_nodes
   );
@@ -468,6 +471,7 @@ static void slider_index_min_core_impl(const double* p_x,
     min_state_finalize,
     min_nodes_increment,
     min_nodes_initialize,
+    min_nodes_void_deref,
     na_rm ? min_na_rm_aggregate_from_leaves : min_na_keep_aggregate_from_leaves,
     na_rm ? min_na_rm_aggregate_from_nodes : min_na_keep_aggregate_from_nodes
   );
@@ -552,6 +556,7 @@ static void slider_index_max_core_impl(const double* p_x,
     max_state_finalize,
     max_nodes_increment,
     max_nodes_initialize,
+    max_nodes_void_deref,
     na_rm ? max_na_rm_aggregate_from_leaves : max_na_keep_aggregate_from_leaves,
     na_rm ? max_na_rm_aggregate_from_nodes : max_na_keep_aggregate_from_nodes
   );
@@ -636,6 +641,7 @@ static void slider_index_all_core_impl(const int* p_x,
     all_state_finalize,
     all_nodes_increment,
     all_nodes_initialize,
+    all_nodes_void_deref,
     na_rm ? all_na_rm_aggregate_from_leaves : all_na_keep_aggregate_from_leaves,
     na_rm ? all_na_rm_aggregate_from_nodes : all_na_keep_aggregate_from_nodes
   );
@@ -720,6 +726,7 @@ static void slider_index_any_core_impl(const int* p_x,
     any_state_finalize,
     any_nodes_increment,
     any_nodes_initialize,
+    any_nodes_void_deref,
     na_rm ? any_na_rm_aggregate_from_leaves : any_na_keep_aggregate_from_leaves,
     na_rm ? any_na_rm_aggregate_from_nodes : any_na_keep_aggregate_from_nodes
   );

--- a/src/summary-slide.c
+++ b/src/summary-slide.c
@@ -151,6 +151,7 @@ static inline void slide_sum_impl(const double* p_x,
     sum_state_finalize,
     sum_nodes_increment,
     sum_nodes_initialize,
+    sum_nodes_void_deref,
     na_rm ? sum_na_rm_aggregate_from_leaves : sum_na_keep_aggregate_from_leaves,
     na_rm ? sum_na_rm_aggregate_from_nodes : sum_na_keep_aggregate_from_nodes
   );
@@ -189,6 +190,7 @@ static inline void slide_prod_impl(const double* p_x,
     prod_state_finalize,
     prod_nodes_increment,
     prod_nodes_initialize,
+    prod_nodes_void_deref,
     na_rm ? prod_na_rm_aggregate_from_leaves : prod_na_keep_aggregate_from_leaves,
     na_rm ? prod_na_rm_aggregate_from_nodes : prod_na_keep_aggregate_from_nodes
   );
@@ -227,6 +229,7 @@ static inline void slide_mean_impl(const double* p_x,
     mean_state_finalize,
     mean_nodes_increment,
     mean_nodes_initialize,
+    mean_nodes_void_deref,
     na_rm ? mean_na_rm_aggregate_from_leaves : mean_na_keep_aggregate_from_leaves,
     na_rm ? mean_na_rm_aggregate_from_nodes : mean_na_keep_aggregate_from_nodes
   );
@@ -265,6 +268,7 @@ static inline void slide_min_impl(const double* p_x,
     min_state_finalize,
     min_nodes_increment,
     min_nodes_initialize,
+    min_nodes_void_deref,
     na_rm ? min_na_rm_aggregate_from_leaves : min_na_keep_aggregate_from_leaves,
     na_rm ? min_na_rm_aggregate_from_nodes : min_na_keep_aggregate_from_nodes
   );
@@ -303,6 +307,7 @@ static inline void slide_max_impl(const double* p_x,
     max_state_finalize,
     max_nodes_increment,
     max_nodes_initialize,
+    max_nodes_void_deref,
     na_rm ? max_na_rm_aggregate_from_leaves : max_na_keep_aggregate_from_leaves,
     na_rm ? max_na_rm_aggregate_from_nodes : max_na_keep_aggregate_from_nodes
   );
@@ -341,6 +346,7 @@ static inline void slide_all_impl(const int* p_x,
     all_state_finalize,
     all_nodes_increment,
     all_nodes_initialize,
+    all_nodes_void_deref,
     na_rm ? all_na_rm_aggregate_from_leaves : all_na_keep_aggregate_from_leaves,
     na_rm ? all_na_rm_aggregate_from_nodes : all_na_keep_aggregate_from_nodes
   );
@@ -379,6 +385,7 @@ static inline void slide_any_impl(const int* p_x,
     any_state_finalize,
     any_nodes_increment,
     any_nodes_initialize,
+    any_nodes_void_deref,
     na_rm ? any_na_rm_aggregate_from_leaves : any_na_keep_aggregate_from_leaves,
     na_rm ? any_na_rm_aggregate_from_nodes : any_na_keep_aggregate_from_nodes
   );

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,27 +27,6 @@ SEXP slider_ns_env = NULL;
 
 // -----------------------------------------------------------------------------
 
-const void* r_const_deref(SEXP x, SEXPTYPE type) {
-  switch (type) {
-  case INTSXP: return INTEGER_RO(x);
-  case REALSXP: return REAL_RO(x);
-  case RAWSXP: return RAW_RO(x);
-  default: Rf_errorcall(R_NilValue, "Internal error in `r_const_deref()`: Can't deref `type`.");
-  }
-}
-
-void* r_deref(SEXP x, SEXPTYPE type) {
-  switch (type) {
-  case LGLSXP: return LOGICAL(x);
-  case INTSXP: return INTEGER(x);
-  case REALSXP: return REAL(x);
-  case RAWSXP: return RAW(x);
-  default: Rf_errorcall(R_NilValue, "Internal error in `r_deref()`: Can't deref `type`.");
-  }
-}
-
-// -----------------------------------------------------------------------------
-
 #define SLIDER_INIT_ATOMIC(CTYPE, DEREF, NA_VALUE) do {        \
   SEXP out = PROTECT(Rf_allocVector(type, size));              \
   CTYPE* p_out = DEREF(out);                                   \

--- a/src/utils.h
+++ b/src/utils.h
@@ -85,9 +85,6 @@ extern SEXP slider_shared_na_lgl;
 
 extern SEXP slider_ns_env;
 
-const void* r_const_deref(SEXP x, SEXPTYPE type);
-void* r_deref(SEXP x, SEXPTYPE type);
-
 SEXP slider_init(SEXPTYPE type, R_xlen_t size);
 
 void stop_not_all_size_one(int iteration, int size);


### PR DESCRIPTION
CRAN's GCC USBAN build is erroring with messages like:

```c
summary-core.h:38:16: runtime error: store to misaligned address 0x625000f7fb78 for type 'long double', which requires 16 byte alignment
0x625000f7fb78: note: pointer points here
 00 00 00 00  4d 79 65 72 73 4d 62 61  53 65 73 00 50 62 00 00  4d 00 00 51 01 00 00 00  48 65 c9 01
              ^ 
    #0 0x7f46c992b84c in sum_nodes_initialize /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-core.h:38
    #1 0x7f46c99243f7 in new_segment_tree /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/segment-tree.c:35
    #2 0x7f46c993108d in slider_index_sum_core_impl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:211
    #3 0x7f46c9927df0 in slide_index_summary_dbl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:116
    #4 0x7f46c99318e6 in slide_index_sum_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:246
    #5 0x7f46c99318e6 in slider_index_summary /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:30
    #6 0x7f46c99318e6 in slider_index_sum_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:266
```

```c
summary-core.h:54:7: runtime error: load of misaligned address 0x625000f7fb78 for type 'long double', which requires 16 byte alignment
0x625000f7fb78: note: pointer points here
 00 00 00 00  00 00 00 00 00 00 00 00  00 00 73 00 50 62 00 00  4d 00 00 51 01 00 00 00  48 65 c9 01
              ^ 
    #0 0x7f46c9928909 in sum_na_keep_aggregate_from_leaves /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-core.h:54
    #1 0x7f46c9924617 in segment_tree_initialize_levels /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/segment-tree.c:74
    #2 0x7f46c9924617 in new_segment_tree /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/segment-tree.c:44
    #3 0x7f46c993108d in slider_index_sum_core_impl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:211
    #4 0x7f46c9927df0 in slide_index_summary_dbl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:116
    #5 0x7f46c99318e6 in slide_index_sum_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:246
    #6 0x7f46c99318e6 in slider_index_summary /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:30
    #7 0x7f46c99318e6 in slider_index_sum_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:266
```

and similar for `mean_state_t`

```c
summary-core.h:278:20: runtime error: member access within misaligned address 0x62500f311638 for type 'struct mean_state_t', which requires 16 byte alignment
0x62500f311638: note: pointer points here
 00 00 00 00  be be be be be be be be  be be be be be be be be  be be be be be be be be  be be be be
              ^ 
    #0 0x7f46c992bb2e in mean_nodes_initialize /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-core.h:278
    #1 0x7f46c99243f7 in new_segment_tree /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/segment-tree.c:35
    #2 0x7f46c992bd78 in slider_index_mean_core_impl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:379
    #3 0x7f46c9927df0 in slide_index_summary_dbl /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:116
    #4 0x7f46c99319e6 in slide_index_mean_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:414
    #5 0x7f46c99319e6 in slider_index_summary /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:30
    #6 0x7f46c99319e6 in slider_index_mean_core /data/gannet/ripley/R/packages/tests-gcc-SAN/slider/src/summary-index.c:434
```

It turns out that `(long double*) Rf_allocVector(RAWSXP, size)` does not produce a long double pointer that is "aligned" correctly for long doubles. In R, there is `R_allocLD()`, which performs a trick to allocate the vector + a little buffer, and then realign the pointer to it so it is aligned correctly
https://github.com/wch/r-source/blob/92e2a4671e027ce7d048fd20c3c187657507b3e8/src/main/memory.c#L2278-L2296

However, `R_allocLD()` was broken until very recently (R 4.0.3), as reported by this R bugzilla report
https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16534

Even if it was fixed, we could not rely on it to allocate the array of `struct mean_state_t` correctly, since that is more complex.

Instead, we take the approach of this SO answer (which is basically what `R_allocLD()` does anyways). We use the "generalized version" of the answer, as that works for `long double` and our `mean_state_t` type.
https://stackoverflow.com/questions/227897/how-to-allocate-aligned-memory-only-using-the-standard-library

To use this, we need to get the alignment (it isn't always 16 like in the SO question), and to get that we need `alignof()`. This is a C++11 addition, so we have a separate compilation unit that uses C++11, which we then call from our other C files. Technically this is also in C11, but it is uncertain how well R supports that. We do have experience using C++11 in other packages, so it should be safe.