### PR TITLE
Switch to `vec_rank()` for dense ranks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # slider (development version)
 
+* The `slide_index_*()` and `hop_index_*()` families now use `vctrs::vec_rank()`
+  internally to compute a dense rank, which should be a little faster than the
+  previous home grown approach (#177).
+
 * Removed `R_forceAndCall()` fallback now that R >=3.4.0 is required (#172).
 
 * Fixed `-Wstrict-prototypes` warnings as requested by CRAN (#173).

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,9 +84,11 @@ vec_simplify <- function(x, ptype) {
 
 compute_combined_ranks <- function(...) {
   args <- list2(...)
-  combined <- vec_c(!!!args, .name_spec = zap())
+  combined <- list_unchop(args, name_spec = zap())
 
-  ranks <- slider_dense_rank(combined)
+  # Expected that there are no missing values in `combined`.
+  # Incomplete rows do get ranked, with missing values coming last.
+  ranks <- vec_rank(combined, ties = "dense")
 
   n_args <- length(args)
   sizes <- list_sizes(args)
@@ -105,13 +107,3 @@ compute_combined_ranks <- function(...) {
 
   out
 }
-
-# TODO: Replace with `vec_rank(x, ties = "dense")`
-# https://github.com/r-lib/vctrs/issues/1251
-#
-# This impl is taken from `dplyr::dense_rank()`.
-# Expected that there are no missing values in `x`.
-slider_dense_rank <- function(x) {
-  vec_match(x, vec_sort(vec_unique(x)))
-}
-


### PR DESCRIPTION
Closes #177 