### PR TITLE
Avoid `name_spec = zap()` for now

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # slider (development version)
 
+* Index (`.i`) types that aren't explicitly understood by vctrs are now handled
+  slightly better (#182).
+
 * The `slide_index_*()` and `hop_index_*()` families now use `vctrs::vec_rank()`
   internally to compute a dense rank, which should be a little faster than the
   previous home grown approach (#177).

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,7 +84,11 @@ vec_simplify <- function(x, ptype) {
 
 compute_combined_ranks <- function(...) {
   args <- list2(...)
-  combined <- list_unchop(args, name_spec = zap())
+
+  # TODO: Ideally we'd set `name_spec = zap()` to drop names from both `args`
+  # and its elements for performance, but that doesn't work for non-vctrs types.
+  # https://github.com/r-lib/vctrs/issues/1106
+  combined <- list_unchop(unname(args))
 
   # Expected that there are no missing values in `combined`.
   # Incomplete rows do get ranked, with missing values coming last.

--- a/tests/testthat/test-slide-index.R
+++ b/tests/testthat/test-slide-index.R
@@ -845,6 +845,54 @@ test_that("can use Durations/Periods to handle daylight savings differently", {
 })
 
 # ------------------------------------------------------------------------------
+# .before / .after - non-vctrs types
+
+test_that(".i/.before/.after can be non-vctrs types (#182)", {
+  local_c_foobar()
+
+  i <- foobar(1:4)
+  x <- seq_along(i)
+
+  expect_identical(
+    slide_index(x, i, identity, .before = 2L),
+    list(
+      1L,
+      1:2,
+      1:3,
+      2:4
+    )
+  )
+  expect_identical(
+    slide_index(x, i, identity, .before = foobar(2L)),
+    list(
+      1L,
+      1:2,
+      1:3,
+      2:4
+    )
+  )
+
+  expect_identical(
+    slide_index(x, i, identity, .after = 2L),
+    list(
+      1:3,
+      2:4,
+      3:4,
+      4L
+    )
+  )
+  expect_identical(
+    slide_index(x, i, identity, .after = foobar(2L)),
+    list(
+      1:3,
+      2:4,
+      3:4,
+      4L
+    )
+  )
+})
+
+# ------------------------------------------------------------------------------
 # .before / .after - function
 
 test_that(".before/.after - can use a function", {


### PR DESCRIPTION
Closes #182 